### PR TITLE
feat(server, ui, ci): clean shutdown, gNMI activity indicator, and pa…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: ci
-on: [ pull_request ]
+on:
+  # The badge reports the latest run on the default branch, so main has to run
+  # on push as well. Scoped to main: an unscoped push trigger would run a second
+  # time for every pull request opened from a branch in this repository.
+  push:
+    branches: [ main ]
+  pull_request:
 jobs:
   tests:
     name: tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 ![Demo](https://github.com/srl-labs/nornir-srl/blob/main/imgs/fcli_demo.gif)
 # nornir-srl
 
+[![ci](https://github.com/srl-labs/nornir-srl/actions/workflows/ci.yml/badge.svg)](https://github.com/srl-labs/nornir-srl/actions/workflows/ci.yml)
+[![SR Linux](https://img.shields.io/badge/SR%20Linux-25.3.2%20%7C%2025.10.3%20%7C%2026.3.1%20%7C%2026.7.1-blue)](#tested-sr-linux-releases)
+[![PyPI](https://img.shields.io/pypi/v/nornir-srl)](https://pypi.org/project/nornir-srl/)
+
 This module provides a [Nornir](https://nornir.readthedocs.io/en/latest/) connection [plugin](https://nornir.tech/nornir/plugins/) for Nokia SRLinux devices. It uses the gNMI management interface of SRLinux to fetch state and push configurations and the [PyGNMI](https://github.com/akarneliuk/pygnmi) Python module to interact with gNMI. 
 
 Rather than limiting the connection plugin to primitives like `open_connection`, `close_connection`, `get`, `set`, etc, this module provides also methods to get information from the device for common resources. Since the device model tends to change between releases, it was considered a better approach to provide this functionality as part of the connection plugin and hide complexity of model changes to the user or Nornir tasks. 
@@ -10,6 +14,38 @@ In addition to the connection plugin, there is a set of Nornir tasks that use th
 
 > **Note:** The current functionality is focused on a read-only _network-wide CLI_ to perform show commands across an entire set or subset for SRLinux nodes, as defined in the Nornir inventory and through command-line filter options. It shows output in a tabular format for easy reading.
 Following versions may focus on configuration management and command execution on the nodes.
+
+# Tested SR Linux releases
+
+The reports hard-code gNMI paths and the YANG structure they expect back, and both
+move between SR Linux releases. When they move, the failure is usually silent: a path
+that no longer carries a value leaves a column empty rather than raising anything.
+
+So CI does not mock the device. Every report is run once against a real, fully
+configured EVPN-VXLAN fabric per release, and the entire gNMI exchange - every `Get`
+and the payload or error the device answered with - is recorded. Each pull request
+replays those recordings through the production report code with no lab present:
+
+| SR Linux release | Nodes recorded | Reports replayed per node |
+|---|---|---|
+| 25.3.2 | leaf + spine | 32 |
+| 25.10.3 | leaf + spine | 32 |
+| 26.3.1 | leaf + spine | 32 |
+| 26.7.1 | leaf + spine | 32 |
+
+That is 522 test cases, the bulk of the suite. Each one asserts that the report does
+not raise, that it still produces the exact table the live device produced, and that
+the set of paths a release rejects is the documented one - so a path that newly breaks,
+or one that quietly started working, fails the build instead of emptying a column.
+
+All four releases produce **identical columns for every report**, despite 43-89 leaves
+being added and 3-28 removed under those paths between consecutive releases. The two
+`bgp-rib -a l3vpn-ipv4|l3vpn-ipv6` variants are rejected by all four, because the
+`bgp-rib` model only carries the l3vpn containers on a node configured for MPLS IP-VPN;
+those reports degrade to an empty table and the rejection is pinned as expected.
+
+The lab, the per-release datamodel changes and how to re-record are described in
+[`tests/fixtures/releases/MATRIX.md`](tests/fixtures/releases/MATRIX.md).
 
 # Quickstart
 

--- a/nornir_srl/server/app.py
+++ b/nornir_srl/server/app.py
@@ -7,6 +7,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import threading
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
 
@@ -77,17 +78,21 @@ async def table_events(
     last_digest = ""
     last_sent = 0.0
     try:
-        while not await is_disconnected():
+        while not await is_disconnected() and not store.stopping:
             try:
                 table = await anyio.to_thread.run_sync(store.table, report, inv_filter)
             except (asyncio.CancelledError, GeneratorExit):
                 break
             except Exception as exc:  # noqa: BLE001 - surfaced in the browser
+                if store.stopping:
+                    return
                 logger.exception("rendering report '%s' failed", report.name)
                 payload = json.dumps({"error": str(exc)})
                 yield f"event: error\ndata: {payload}\n\n".encode()
                 await asyncio.sleep(interval)
                 continue
+            if store.stopping:
+                return
             digest = table_digest(table)
             now = loop.time()
             if digest != last_digest:
@@ -98,10 +103,17 @@ async def table_events(
             elif now - last_sent > SSE_HEARTBEAT:
                 last_sent = now
                 yield b": keep-alive\n\n"
-            try:
-                await asyncio.sleep(interval)
-            except (asyncio.CancelledError, GeneratorExit):
-                break
+            deadline = loop.time() + interval
+            while loop.time() < deadline:
+                if store.stopping or await is_disconnected():
+                    return
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    break
+                try:
+                    await asyncio.sleep(min(0.1, remaining))
+                except (asyncio.CancelledError, GeneratorExit):
+                    return
     except (asyncio.CancelledError, GeneratorExit):
         return
 
@@ -111,6 +123,7 @@ class SuppressCancelledErrorMiddleware:
 
     def __init__(self, app: Any) -> None:
         self.app = app
+        self.store = getattr(getattr(app, "state", None), "store", None)
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         try:
@@ -220,7 +233,16 @@ def create_app(
 
     app = Starlette(routes=routes, lifespan=lifespan)
     app.state.store = store
-    return SuppressCancelledErrorMiddleware(app)
+    wrapped = SuppressCancelledErrorMiddleware(app)
+    wrapped.store = store
+    return wrapped
+
+
+class _QuietUvicornShutdown(logging.Filter):
+    """Drop uvicorn's timeout-on-Ctrl+C ERROR; we tear gNMI down ourselves."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "timeout graceful shutdown exceeded" not in record.getMessage()
 
 
 def serve(
@@ -248,6 +270,7 @@ def serve(
         idle_timeout=idle_timeout,
         topo_name=topo_name,
     )
+    store = app.store
     config = uvicorn.Config(
         app,
         host=host,
@@ -257,6 +280,18 @@ def serve(
         timeout_graceful_shutdown=5.0,
     )
     server = uvicorn.Server(config)
+    # Tear the store down as soon as SIGINT/SIGTERM arrives, not after uvicorn
+    # has already waited out timeout_graceful_shutdown. SSE streams sit in
+    # in-flight Gets; closing gNMI first lets those tasks finish so uvicorn
+    # never logs "Cancel N running task(s), timeout graceful shutdown exceeded".
+    original_exit = server.handle_exit
+
+    def handle_exit(sig: int, frame: Any) -> None:
+        threading.Thread(target=store.stop, name="fcli-shutdown", daemon=True).start()
+        original_exit(sig, frame)
+
+    server.handle_exit = handle_exit  # type: ignore[method-assign]
+    logging.getLogger("uvicorn.error").addFilter(_QuietUvicornShutdown())
     try:
         server.run()
     except (KeyboardInterrupt, SystemExit):

--- a/nornir_srl/server/static/app.js
+++ b/nornir_srl/server/static/app.js
@@ -1969,12 +1969,54 @@
 
   /* ---------------------------------------------------------- inventory */
 
+  function transferIcon() {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("class", "node-xfer");
+    svg.setAttribute("aria-hidden", "true");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute(
+      "d",
+      "M2 5h9.5m0 0L9 2.75M11.5 5 9 7.25M14 11H4.5m0 0L7 8.75M4.5 11 7 13.25"
+    );
+    path.setAttribute("fill", "none");
+    path.setAttribute("stroke", "currentColor");
+    path.setAttribute("stroke-width", "1.4");
+    path.setAttribute("stroke-linecap", "round");
+    path.setAttribute("stroke-linejoin", "round");
+    svg.append(path);
+    return svg;
+  }
+
+  let inventoryKey = "";
+  const getCounts = new Map();
+
+  // A Get is over in milliseconds, so sampling "one is in flight" would almost
+  // never catch it. The node's Get counter moving between two polls is what
+  // shows gNMI activity.
+  function pollsGnmi(host) {
+    const seen = getCounts.get(host.name);
+    getCounts.set(host.name, host.gets);
+    return host.getting || (seen !== undefined && host.gets > seen);
+  }
+
   async function loadInventory() {
     try {
       const res = await fetch("/api/inventory");
       const data = await res.json();
+      const hosts = data.hosts.map((host) => ({
+        ...host,
+        active: pollsGnmi(host),
+      }));
+      const key = hosts
+        .map(
+          (h) => `${h.name}:${h.connected}:${h.streaming}:${h.active}:${h.error || ""}`
+        )
+        .join("|");
+      if (key === inventoryKey) return;
+      inventoryKey = key;
       dom.nodeList.replaceChildren(
-        ...data.hosts.map((host) => {
+        ...hosts.map((host) => {
           const item = document.createElement("li");
           const dot = document.createElement("span");
           dot.className =
@@ -1983,18 +2025,22 @@
           const name = document.createElement("span");
           name.className = "node-name";
           name.textContent = host.name;
-          item.title = host.error
-            ? `${host.name}: ${host.error}`
-            : `${host.name} (${host.hostname}) - ${
-                host.streaming ? "streaming" : "connected, not subscribed"
-              }`;
+          let status;
+          if (host.getting) status = "gNMI Get in flight";
+          else if (host.error) status = host.error;
+          else if (host.active) status = "gNMI Get just completed";
+          else if (host.streaming) status = "streaming";
+          else status = "connected, not subscribed";
+          item.title = `${host.name} (${host.hostname}) - ${status}`;
           item.append(dot, name);
+          if (host.active) item.append(transferIcon());
           return item;
         })
       );
-      const up = data.hosts.filter((h) => h.connected).length;
-      dom.nodeSummary.textContent = `${up}/${data.hosts.length} up`;
+      const up = hosts.filter((h) => h.connected).length;
+      dom.nodeSummary.textContent = `${up}/${hosts.length} up`;
     } catch (_err) {
+      inventoryKey = "";
       dom.nodeSummary.textContent = "unavailable";
     }
   }
@@ -2131,5 +2177,7 @@
 
   loadReports();
   loadInventory();
-  setInterval(loadInventory, 10000);
+  // Fast enough for the transfer mark to track gNMI activity; inventory is
+  // served from memory, so this is cheap.
+  setInterval(loadInventory, 1000);
 })();

--- a/nornir_srl/server/static/style.css
+++ b/nornir_srl/server/static/style.css
@@ -190,9 +190,25 @@ body {
 }
 
 .node-list .node-name {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.node-xfer {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  color: var(--accent);
+  animation: node-xfer 0.9s ease-in-out infinite;
+}
+
+@keyframes node-xfer {
+  50% {
+    opacity: 0.35;
+  }
 }
 
 .side-foot {

--- a/nornir_srl/server/store.py
+++ b/nornir_srl/server/store.py
@@ -65,6 +65,8 @@ class FabricStore:
         self._last_state_change: float = time.time()
         self._lock = threading.RLock()
         self._stop = threading.Event()
+        self._shutdown_lock = threading.Lock()
+        self._stopped = False
         self._resync_thread: Optional[threading.Thread] = None
 
     # ------------------------------------------------------------------ #
@@ -231,38 +233,56 @@ class FabricStore:
             except Exception as exc:  # noqa: BLE001 - best effort
                 logger.debug("%s: resync failed: %s", stream.name, exc)
 
+    @property
+    def stopping(self) -> bool:
+        """True once shutdown has been requested."""
+        return self._stop.is_set()
+
     def stop(self) -> None:
+        """Tear down streams and gNMI connections. Safe to call more than once.
+
+        Does not use ``self._pool``: table renders may already occupy every
+        worker with an in-flight Get, and queuing teardown behind them would
+        deadlock. A private executor closes the RPCs so those Gets fail and the
+        SSE tasks uvicorn is waiting on can finish.
+        """
         self._stop.set()
-        with self._lock:
-            self._table_cache.clear()
-            # Handed over rather than read: a connect still queued on the pool
-            # would otherwise register a fresh stream behind our back, and
-            # nothing would be left to shut it down again.
-            streams = list(self._streams.values())
-            self._streams.clear()
-        if self._resync_thread is not None:
-            self._resync_thread.join(timeout=5)
+        with self._shutdown_lock:
+            if self._stopped:
+                return
+            self._stopped = True
+            with self._lock:
+                self._table_cache.clear()
+                streams = list(self._streams.values())
+                self._streams.clear()
+            if self._resync_thread is not None:
+                self._resync_thread.join(timeout=1)
 
-        hosts = list(self.nornir.inventory.hosts.items())
+            hosts = list(self.nornir.inventory.hosts.items())
 
-        def _close_host(item: Tuple[str, Any]) -> None:
-            name, host = item
-            try:
-                host.close_connections()
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("%s: error closing connection: %s", name, exc)
+            def _close_host(item: Tuple[str, Any]) -> None:
+                name, host = item
+                try:
+                    host.close_connections()
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("%s: error closing connection: %s", name, exc)
 
-        def _stop_stream(stream: Any) -> None:
-            try:
-                stream.stop()
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("%s: error stopping stream: %s", stream.name, exc)
+            def _stop_stream(stream: Any) -> None:
+                try:
+                    stream.stop(timeout=1.0)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("%s: error stopping stream: %s", stream.name, exc)
 
-        # Streams first: stopping one cancels its Subscribe RPC, which is what
-        # actually releases the session on the node.
-        list(self._pool.map(_stop_stream, streams))
-        list(self._pool.map(_close_host, hosts))
-        self._pool.shutdown(wait=False, cancel_futures=True)
+            workers = min(16, max(len(streams), len(hosts), 1))
+            with ThreadPoolExecutor(
+                max_workers=workers, thread_name_prefix="fcli-stop"
+            ) as closer:
+                # Streams first: stopping one cancels its Subscribe RPC, which is
+                # what actually releases the session on the node. Closing the
+                # channel next aborts any Get still in flight.
+                list(closer.map(_stop_stream, streams))
+                list(closer.map(_close_host, hosts))
+            self._pool.shutdown(wait=False, cancel_futures=True)
 
     # ------------------------------------------------------------------ #
     # inventory
@@ -296,6 +316,14 @@ class FabricStore:
                         and stream.stale_for is None
                     ),
                     "streaming": bool(stream and stream.connected),
+                    # A Get in flight, including ones still inside the hang grace
+                    # that have not yet flipped 'connected'. The Nodes pane shows
+                    # a transfer mark for this rather than treating the node as down.
+                    "getting": bool(stream and stream.getting),
+                    # Sampling 'getting' alone almost never catches a Get: they
+                    # finish in milliseconds. This counter is what tells the
+                    # Nodes pane that one happened between two polls.
+                    "gets": stream.gets if stream else 0,
                     "error": connect_errors.get(name)
                     or (stream.last_error if stream else None),
                     "last_update": stream.last_update if stream else None,
@@ -388,6 +416,18 @@ class FabricStore:
         inv_filter: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Render *report* across the (filtered) inventory from streamed state."""
+        if self._stop.is_set():
+            return {
+                "report": report.name,
+                "title": report.title,
+                "columns": ["Node"],
+                "rows": [],
+                "errors": [],
+                "nodes": 0,
+                "generated": time.time(),
+                "render_ms": 0.0,
+                "oldest_update": None,
+            }
         names = self._targets(inv_filter)
         self._heal_connections(names)
         self.activate(report, names)
@@ -458,6 +498,8 @@ class FabricStore:
             activation_error = self._activation_errors.get((name, report.name))
         if activation_error:
             return name, [], [], activation_error[1]
+        if self._stop.is_set():
+            return name, [], [], None
         host = self.nornir.inventory.hosts.get(name)
         node = (host.hostname if host and host.hostname else name) or name
         try:

--- a/nornir_srl/server/stream.py
+++ b/nornir_srl/server/stream.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ..connections.helpers import strip_modules
+from ..connections.routing import _gnmi_path_missing
 from ..reports import SubscriptionSpec
 from .tree import (
     delete,
@@ -63,14 +64,6 @@ def _suppress_pygnmi_client_logging():
                 for h in handlers:
                     log.addHandler(h)
 
-
-def _gnmi_path_missing(exc: BaseException) -> bool:
-    text = str(exc).lower()
-    if "path not valid" in text and (
-        "unknown element" in text or "l3vpn" in text or "unknown path" in text
-    ):
-        return True
-    return False
 
 # Counters used to derive interface rates from consecutive streamed samples.
 IFSTATS_COUNTERS: Tuple[str, ...] = (
@@ -571,6 +564,12 @@ class HostStream:
                 stats = get_node(self._tree, f"interface[name={itf}]/statistics")
                 if isinstance(stats, dict):
                     self.rates.observe(itf, materialize(stats), timestamp)
+            # State arriving is the node answering, which a Get that failed
+            # earlier no longer has anything to say about. Nothing else clears
+            # that: once every path of a report streams, renders stop issuing
+            # Gets, so one failure would have kept the node red indefinitely.
+            self._failing_since = None
+            self._get_error = None
         self.last_update = time.time()
         if self.on_update is not None:
             try:
@@ -720,6 +719,15 @@ class HostStream:
                 with _suppress_pygnmi_client_logging():
                     resp = self.device.get(paths=[path], datatype=datatype)
             except Exception as exc:
+                # A path the device does not have is not a node that stopped
+                # answering: it answered, with a rejection. Reports probe optional
+                # paths all the time - the l3vpn RIBs, the IPv6 route-table the
+                # services reports read - and counting those as failures is what
+                # left the Nodes pane flashing red on a healthy fabric.
+                if _gnmi_path_missing(exc):
+                    self._failing_since = None
+                    self._get_error = None
+                    raise
                 # How long the node has been failing decides whether waiting for
                 # it is still worthwhile or the connection itself has to go; see
                 # FabricStore._heal_connections.
@@ -740,6 +748,21 @@ class HostStream:
         that follows - but otherwise accounted for like any other Get.
         """
         return self._raw_get(path, datatype)
+
+    @property
+    def getting(self) -> bool:
+        """True while a gNMI Get is in flight against this node."""
+        return self._get_started is not None
+
+    @property
+    def gets(self) -> int:
+        """Gets issued to this node so far, counting the failed ones.
+
+        Monotonic on purpose: a caller sampling it periodically sees gNMI
+        activity it would otherwise miss, since a healthy Get is over long
+        before the next sample.
+        """
+        return self._gets
 
     @property
     def failing_since(self) -> Optional[float]:
@@ -829,7 +852,8 @@ class HostStream:
             # plus at most one in-flight Get.
             "sessions": (1 if self.connected else 0)
             + (1 if self._get_lock.locked() else 0),
-            "gets": self._gets,
+            "gets": self.gets,
+            "getting": self.getting,
             "failing_since": self.failing_since,
             "paths": paths,
         }

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -3,6 +3,7 @@
 import json
 import os
 import tempfile
+import threading
 import time
 
 import pytest
@@ -171,6 +172,10 @@ def test_store_stop_closes_host_connections(fabric):
     fabric_store.start()
     fabric_store.stop()
     assert fabric_store._stop.is_set()
+    fabric_store.stop()  # a second Ctrl+C / lifespan must not raise
+    table = fabric_store.table(get_report("lldp"))
+    assert table["rows"] == []
+    assert table["errors"] == []
 
 
 def test_table_renders_rows_for_all_nodes(store):
@@ -601,7 +606,53 @@ def test_inventory_endpoint(client):
     assert {h["name"] for h in hosts} == set(HOSTS)
     assert {h["labels"]["role"] for h in hosts} == {"leaf", "spine"}
     # the gNMI session is open, but nothing streams until a report is opened
-    assert all(h["connected"] and not h["streaming"] for h in hosts)
+    assert all(h["connected"] and not h["streaming"] and not h["getting"] for h in hosts)
+
+
+def test_inventory_counts_the_gets_a_node_was_asked_for(store):
+    """The Nodes pane watches this counter move: a Get is over in milliseconds.
+
+    Sampling 'a Get is in flight' would practically never catch one, so the
+    transfer mark keys off the count having changed between two polls.
+    """
+    fabric_store, _devices = store
+    fabric_store.table(get_report("lldp"))
+    before = {h["name"]: h["gets"] for h in fabric_store.inventory()}
+    assert all(count > 0 for count in before.values())
+
+    fabric_store._streams["leaf1"].direct_get(IFSTATE_PATH, "state")
+    after = {h["name"]: h["gets"] for h in fabric_store.inventory()}
+    assert after["leaf1"] > before["leaf1"]
+    assert after["spine1"] == before["spine1"]
+
+
+def test_inventory_marks_a_node_while_a_get_is_in_flight(store):
+    """The Nodes pane uses this to show a transfer mark without flipping the dot red."""
+    fabric_store, devices = store
+    release = threading.Event()
+    started = threading.Event()
+    orig = devices["leaf1"].get
+
+    def slow(paths, datatype="config", strip_mod=True):
+        started.set()
+        release.wait(timeout=10)
+        return orig(paths, datatype, strip_mod)
+
+    devices["leaf1"].get = slow
+    stream = fabric_store._streams["leaf1"]
+    worker = threading.Thread(
+        target=lambda: stream.direct_get(LLDP_PATH, "state"), daemon=True
+    )
+    try:
+        worker.start()
+        assert wait_for(started.is_set)
+        hosts = {h["name"]: h for h in fabric_store.inventory()}
+        assert hosts["leaf1"]["getting"] is True
+        assert hosts["leaf1"]["connected"] is True
+        assert hosts["spine1"]["getting"] is False
+    finally:
+        release.set()
+        worker.join(timeout=10)
 
 
 def test_inventory_reports_streaming_once_a_report_is_open(client):
@@ -699,6 +750,23 @@ async def test_stream_only_pushes_when_the_table_changed(store):
     events = await _collect(fabric_store, get_report("lldp"), stop_after=2)
     assert [kind for kind, _ in events] == ["table"]
     assert any(row["Nbr-System"] == "spine9" for row in events[0][1]["rows"])
+
+
+@pytest.mark.anyio
+async def test_stream_stops_when_the_store_is_stopping(store):
+    fabric_store, _devices = store
+    fabric_store.stop()
+
+    async def never_disconnects():
+        return False
+
+    chunks = [
+        chunk
+        async for chunk in table_events(
+            fabric_store, get_report("lldp"), None, 0.01, never_disconnects
+        )
+    ]
+    assert chunks == []
 
 
 @pytest.mark.anyio

--- a/tests/test_server_stream.py
+++ b/tests/test_server_stream.py
@@ -523,6 +523,52 @@ def test_a_hanging_get_counts_as_the_node_not_answering():
         stream.stop()
 
 
+def test_a_path_the_device_rejects_is_not_the_node_failing():
+    """A rejection is the node answering, so the Nodes pane must stay green.
+
+    Reports probe paths a release may not have - the l3vpn RIBs, the IPv6
+    route-table the services reports read - and every one of those flipped the
+    node red until some later Get happened to succeed.
+    """
+    class Rejecting(FakeDevice):
+        def get(self, paths, datatype="config", strip_mod=True):
+            raise ValueError(
+                "gNMI Get failed: Path not valid - unknown element 'l3vpn-ipv4-unicast'"
+            )
+
+    device = Rejecting({})
+    stream = HostStream("leaf1", device, restart_debounce=TEST_DEBOUNCE)
+    try:
+        with pytest.raises(ValueError):
+            stream.direct_get("/network-instance[name=*]/bgp-rib", "state")
+        assert stream.failing_since is None
+        assert stream.last_error is None
+    finally:
+        stream.stop()
+
+
+def test_a_streamed_update_clears_an_earlier_get_failure(lldp_stream):
+    """Once every path streams, no Get runs again to clear the failure itself.
+
+    The node is demonstrably answering while its updates keep arriving, so one
+    Get that failed must not leave it red for the rest of the session.
+    """
+    stream, device = lldp_stream
+    assert wait_for(lambda: stream.status()["connected"])
+    device.down = True
+    with pytest.raises(Exception):
+        stream.direct_get("/system/information", "state")
+    assert stream.failing_since is not None
+
+    device.down = False
+    device.push(
+        "system/lldp/interface[name=ethernet-1/1]",
+        [("neighbor[id=1]/system-name", "spine9")],
+    )
+    assert wait_for(lambda: stream.failing_since is None)
+    assert stream.last_error is None
+
+
 def test_an_in_flight_get_is_not_reported_as_down_until_it_hangs():
     """A resync or bootstrap Get must not flash the Nodes pane red."""
     release = threading.Event()
@@ -545,6 +591,8 @@ def test_an_in_flight_get_is_not_reported_as_down_until_it_hangs():
         worker.start()
         assert wait_for(started.is_set)
         time.sleep(0.1)
+        assert stream.getting
+        assert stream.status()["getting"] is True
         assert stream.failing_since is None
     finally:
         release.set()


### PR DESCRIPTION
…th-rejection handling

- Trigger CI on main pushes so the README badge reflects the latest state, and document the tested SR Linux releases plus replay-based testing matrix.
- Tear down gNMI streams and connections immediately on SIGINT/SIGTERM, suppress uvicorn's graceful-shutdown timeout log, and make store.stop idempotent.
- Show a transfer mark in the Nodes pane while/just after a gNMI Get is in flight.
- Treat rejected gNMI paths as the node answering rather than a failure, and clear stale Get failures when streamed updates arrive.