### PR TITLE
feat(server, ui): add interactive fabric topology view and fingerprin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,57 @@ to a subset of the fabric (`-i`):
 * **Columns** hides columns you do not need, **CSV** downloads exactly what the
   table currently shows (filters, column selection and all).
 
+## Topology
+
+The **Topology** page draws the fabric from LLDP, one tier per row, and works out
+what each node is from what it runs rather than from an inventory label:
+
+* a node with **mac-vrfs**, and optionally ip-vrfs, is a **leaf** — the tier where
+  a service meets a port;
+* a node whose services carry **two enabled `bgp-vpn` instances** is a **DCGW**:
+  the second instance is the WAN side of a stitched service, which only a gateway
+  out of the DC has;
+* a node with **no mac-vrf and no ip-vrf** that sees two or more leaves is a
+  **spine**: it interconnects them without terminating anything;
+* anything else without services is **WAN / core** — P/PE routers and
+  super-spines, which transit the fabric but attach to no leaf of it.
+
+Under all of them is the **client** tier, which is not made of inventory nodes at
+all but of what the services are configured towards: a bridged sub-interface of a
+mac-vrf, or a routed port of an ip-vrf. Only ports facing nothing else we know of
+count, so the WAN sub-interface of a stitched ip-vrf stays a link to the DCGW's
+neighbour rather than becoming a customer, and IRBs, loopbacks and `system0` are
+left out. Several vlans on one cable are one client, and which ports belong to
+the same client is answered by whichever of these the fabric can tell us: the
+name an unmatched LLDP neighbour advertises, since a client that says who it is
+says the same to every leaf; failing that the **ESI** of the ethernet-segment the
+port is in, which is how a multi-homed client that runs no LLDP is still drawn as
+one box spanning its leaves rather than one box per leaf; and failing both, the
+port itself. Every client box just reads `client`: what it was named after is a
+guess drawn from an ESI or a port, which would read like an identity it does not
+have. Clicking one lists every sub-interface it attaches on, with its service,
+vlan and address, and walks to the leaf from there.
+
+Between the leaves and the clients sit the **ethernet-segments**. A multi-homed
+client reaches its leaves over one bundle rather than a cable each, and that
+bundle is a configured object of its own — it has a name, an ESI every leaf on it
+agrees on, and it is where multi-homing goes wrong — so it gets a tier, with the
+client hanging off it. A segment box reads `ES` and the last two bytes of its
+ESI, which is what tells the segments of a fabric apart; the name each leaf gave
+it is in the panel, where two leaves disagreeing on it shows up.
+
+Cables come from LLDP and are de-duplicated: both ends report the same link, and
+parallel cables between two nodes are drawn as one line marked `2×`. A link is
+coloured by the oper-state of the ports it lands on. Hovering a node pushes back
+everything it is not cabled to; clicking one opens its services and its per-port
+peer list, and clicking a peer from there walks the fabric.
+
+Neighbours are matched back to the inventory through the name they advertise, so
+a containerlab node the inventory calls `clab-dc1-leaf1` is recognized when its
+neighbour reports it as `leaf1`. A neighbour that matches no node of the
+inventory is still drawn, as an *outside* node, and a node that has not streamed
+anything yet is drawn as *unclassified* rather than left out.
+
 ## How the live data works
 
 1. When a report is opened for the first time, the server runs its getter once
@@ -669,6 +720,7 @@ The UI is a client of a small JSON API, which is just as usable from scripts:
 | `GET /api/reports` | The available reports and their metadata |
 | `GET /api/inventory` | Inventory nodes, labels and connection state |
 | `GET /api/status` | Per-node subscription state |
+| `GET /api/topology` | The fabric graph: nodes with their inferred tier, the clients hanging off them, and the links between them |
 | `GET /api/report/{name}` | One rendered table as JSON |
 | `GET /api/stream/{name}` | The same table, pushed as server-sent events |
 

--- a/nornir_srl/reports.py
+++ b/nornir_srl/reports.py
@@ -35,6 +35,17 @@ class SubscriptionSpec:
     """One gNMI subscription entry."""
 
     path: str
+    #: ``state``, ``config`` or ``all``.
+    #:
+    #: A subscription on a single leaf that SR Linux defines as *config* -
+    #: ``network-instance/type``, ``interface/admin-state``,
+    #: ``system/name/host-name`` - has to ask for ``all``. A path is
+    #: bootstrapped with a gNMI ``Get`` before it can be streamed, and a ``Get``
+    #: with datatype ``state`` answers nothing at all for a config leaf: not an
+    #: error, an empty response. The path then stays pending forever and
+    #: whatever reads it renders as if the node had no such data. Subtrees are
+    #: not affected - ``/network-instance[name=*]`` returns the config leaves
+    #: inside it either way.
     datatype: str = "state"
     mode: str = "sample"  # sample | on_change | target_defined
     sample_interval: int = 10  # seconds
@@ -196,15 +207,64 @@ REPORTS: List[ReportSpec] = [
         surfaces=STREAMING,
         subscribe=(
             SubscriptionSpec("/interface[name=*]/statistics", sample_interval=10),
-            SubscriptionSpec("/interface[name=*]/admin-state", sample_interval=10),
+            # 'admin-state', 'description' and 'type' are config leaves: see
+            # SubscriptionSpec.
+            SubscriptionSpec("/interface[name=*]/admin-state", datatype="all", sample_interval=10),
             SubscriptionSpec("/interface[name=*]/oper-state", sample_interval=10),
             SubscriptionSpec("/interface[name=*]/subinterface", datatype="all", sample_interval=10),
-            SubscriptionSpec("/interface[name=*]/description", sample_interval=10),
+            SubscriptionSpec("/interface[name=*]/description", datatype="all", sample_interval=10),
             SubscriptionSpec("/interface[name=*]/ethernet", datatype="all", sample_interval=10),
-            SubscriptionSpec("/network-instance[name=*]/type", sample_interval=10),
+            SubscriptionSpec("/network-instance[name=*]/type", datatype="all", sample_interval=10),
             SubscriptionSpec("/network-instance[name=*]/oper-state", sample_interval=10),
             SubscriptionSpec("/network-instance[name=*]/protocols/bgp/neighbor", datatype="all", sample_interval=10),
             SubscriptionSpec("/network-instance[name=*]/protocols/bgp-vpn", datatype="all", sample_interval=10),
+        ),
+    ),
+    ReportSpec(
+        name="topology",
+        resource="topology",
+        title="Topology",
+        description="Fabric graph from LLDP, with the tier of each node inferred from its services.",
+        # Computed by the store from the streamed trees below, not by a getter.
+        getter=lambda d: {},
+        category="Dashboard",
+        surfaces=STREAMING,
+        # Every path is read as 'all': 'host-name' and 'type' are config leaves,
+        # which a 'state' Get answers nothing for (see SubscriptionSpec), and the
+        # rest are narrow enough that asking for both costs nothing.
+        subscribe=(
+            # LLDP gives the cables; the host-name is what a neighbour is
+            # advertised under, and the only reliable way back to the inventory.
+            SubscriptionSpec(
+                "/system/lldp/interface[name=*]/neighbor",
+                datatype="all",
+                sample_interval=30,
+            ),
+            SubscriptionSpec("/system/name/host-name", datatype="all", sample_interval=30),
+            SubscriptionSpec("/interface[name=*]/oper-state", datatype="all", sample_interval=30),
+            # A node's tier follows from the services on it: mac-vrfs and
+            # ip-vrfs make it a leaf, two bgp-vpn instances make it a DCGW.
+            SubscriptionSpec("/network-instance[name=*]/type", datatype="all", sample_interval=30),
+            SubscriptionSpec(
+                "/network-instance[name=*]/protocols/bgp-vpn",
+                datatype="all",
+                sample_interval=30,
+            ),
+            # The client tier: which subinterfaces a service is configured
+            # towards, and the vlan and address each of them attaches on.
+            SubscriptionSpec(
+                "/network-instance[name=*]/interface",
+                datatype="all",
+                sample_interval=30,
+            ),
+            SubscriptionSpec("/interface[name=*]/subinterface", datatype="all", sample_interval=30),
+            # The ESI a port is in, which is what says the lags of a multi-homed
+            # client on two leaves are one client rather than two.
+            SubscriptionSpec(
+                "/system/network-instance/protocols/evpn/ethernet-segments",
+                datatype="all",
+                sample_interval=30,
+            ),
         ),
     ),
     ReportSpec(

--- a/nornir_srl/server/app.py
+++ b/nornir_srl/server/app.py
@@ -15,7 +15,7 @@ import anyio
 from nornir.core import Nornir
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import FileResponse, JSONResponse, Response, StreamingResponse
+from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
@@ -37,6 +37,25 @@ _SSE_HEADERS = {
     "Connection": "keep-alive",
     "X-Accel-Buffering": "no",
 }
+
+#: Placeholder in index.html for the cache key of the assets it pulls in.
+ASSET_TOKEN = "__ASSETS__"
+
+
+def asset_version() -> str:
+    """A token that changes whenever the bundled JS or CSS does.
+
+    The page itself is served ``no-cache`` so the browser revalidates it on
+    every load, and the assets it references are fingerprinted with this. Left
+    to itself a browser will happily keep serving a page it cached before a
+    feature existed, which shows up as a report whose panel is simply missing:
+    the report list comes from the API and lists it, the markup it needs does
+    not exist, and nothing in the console says why.
+    """
+    newest = max(
+        (STATIC_DIR / name).stat().st_mtime_ns for name in ("app.js", "style.css")
+    )
+    return f"{__version__}-{newest:x}"
 
 
 def parse_kv(values: Optional[str]) -> Optional[Dict[str, str]]:
@@ -165,7 +184,11 @@ def create_app(
             await anyio.to_thread.run_sync(store.stop)
 
     async def index(_request: Request) -> Response:
-        return FileResponse(STATIC_DIR / "index.html")
+        html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+        return HTMLResponse(
+            html.replace(ASSET_TOKEN, asset_version()),
+            headers={"Cache-Control": "no-cache"},
+        )
 
     async def reports(_request: Request) -> Response:
         return JSONResponse(
@@ -186,6 +209,10 @@ def create_app(
     async def overview(request: Request) -> Response:
         inv_filter = parse_kv(request.query_params.get("inv_filter"))
         return JSONResponse(await anyio.to_thread.run_sync(store.overview, inv_filter))
+
+    async def topology(request: Request) -> Response:
+        inv_filter = parse_kv(request.query_params.get("inv_filter"))
+        return JSONResponse(await anyio.to_thread.run_sync(store.topology, inv_filter))
 
     def streamable_report(name: str) -> ReportSpec:
         """The named report, provided the server is able to stream it."""
@@ -226,6 +253,7 @@ def create_app(
         Route("/api/inventory", inventory),
         Route("/api/status", status),
         Route("/api/overview", overview),
+        Route("/api/topology", topology),
         Route("/api/report/{name}", report_once),
         Route("/api/stream/{name}", report_stream),
         Mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static"),

--- a/nornir_srl/server/static/app.js
+++ b/nornir_srl/server/static/app.js
@@ -43,6 +43,12 @@
     errors: el("errors"),
     tableWrap: el("table-wrap"),
     overviewDashboard: el("overview-dashboard"),
+    topologyView: el("topology-view"),
+    topoCanvas: el("topo-canvas"),
+    topoLegend: el("topo-legend"),
+    topoStats: el("topo-stats"),
+    topoDetail: el("topo-detail"),
+    topoPortLabels: el("topo-port-labels"),
     servicesTreeView: el("services-tree-view"),
     viewModeBtn: el("view-mode-btn"),
     headRow: el("head-row"),
@@ -101,6 +107,9 @@
     identityColumn: null,
     firstPaint: true,
     viewMode: "tree",
+    topology: null,
+    topoSelection: null,
+    topoKey: "",
     collapsedCards: new Set(),
     collapsedNodes: new Set(),
     navStack: [],
@@ -108,6 +117,7 @@
   };
 
   let overviewTimer = null;
+  let topologyTimer = null;
   let navSeq = 0;
 
   /* ------------------------------------------------------------ helpers */
@@ -135,6 +145,9 @@
   const isNumeric = (value) =>
     value !== "" && value !== null && value !== undefined && !isNaN(Number(value));
 
+  /** Reports the server computes for a panel of their own, not as a table. */
+  const isPanelReport = (name) => name === "overview" || name === "topology";
+
   /** Natural compare, so ethernet-1/10 sorts after ethernet-1/2. */
   const collator = new Intl.Collator(undefined, {
     numeric: true,
@@ -149,7 +162,7 @@
   /* ------------------------------------------------ persistence */
 
   function saveReportPreferences() {
-    if (!state.report || state.report.name === "overview") return;
+    if (!state.report || isPanelReport(state.report.name)) return;
     try {
       localStorage.setItem(
         `fcli-hidden-${state.report.name}`,
@@ -168,7 +181,7 @@
   }
 
   function loadReportPreferences() {
-    if (!state.report || state.report.name === "overview") return;
+    if (!state.report || isPanelReport(state.report.name)) return;
     state.hidden.clear();
     state.colFilters.clear();
     try {
@@ -210,9 +223,9 @@
     updateFilterUI();
     renderHead();
     renderBody();
-    if (state.report && state.report.name !== "overview") {
-      connect();
-    }
+    if (!state.report) return;
+    if (state.report.name === "topology") loadTopology();
+    else if (state.report.name !== "overview") connect();
   }
 
   /* --------------------------------------------------------- report list */
@@ -394,6 +407,600 @@
     }
   }
 
+  /* ------------------------------------------------------------- topology */
+
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  /** Create an SVG element with its attributes in one call. */
+  function svgEl(name, attrs) {
+    const node = document.createElementNS(SVG_NS, name);
+    for (const key in attrs || {}) node.setAttribute(key, attrs[key]);
+    return node;
+  }
+
+  const ROLE_LABELS = {
+    client: "Client",
+    segment: "Ethernet segment",
+    leaf: "Leaf",
+    spine: "Spine",
+    dcgw: "DCGW",
+    core: "WAN / core",
+    unknown: "Unclassified",
+    external: "Outside inventory",
+  };
+
+  const TOPO = {
+    nodeHeight: 46,
+    minNodeWidth: 96,
+    gapX: 26,
+    siteGap: 30,
+    rowHeight: 122,
+    padLeft: 124, // room for the tier label down the left edge
+    padRight: 28,
+    padY: 24,
+  };
+
+  const shortPort = (port) => String(port || "").replace(/^ethernet-/, "e");
+
+  async function loadTopology() {
+    if (!state.report || state.report.name !== "topology" || state.paused) return;
+    try {
+      const inv = dom.invFilter.value.trim();
+      const params = new URLSearchParams();
+      if (inv) params.set("inv_filter", inv);
+      const res = await fetch("/api/topology" + (inv ? `?${params}` : ""));
+      const graph = await res.json();
+      setLive("live", "live");
+      dom.rowCount.textContent = `${graph.nodes.length} node(s), ${graph.links.length} link(s)`;
+      dom.streamInfo.textContent = `LLDP topology, rendered in ${graph.render_ms} ms`;
+      dom.updated.textContent = "updated " + new Date().toLocaleTimeString();
+      // Re-drawing would drop the hover and lose the scroll position, and a
+      // fabric changes far less often than it is polled.
+      const key = JSON.stringify(graph.nodes) + JSON.stringify(graph.links);
+      if (key === state.topoKey) return;
+      state.topoKey = key;
+      state.topology = graph;
+      renderTopology(graph);
+    } catch (_err) {
+      setLive("error", "error");
+    }
+  }
+
+  /** Place every node on the tier its role puts it in, one row per tier. */
+  function layoutTopology(graph) {
+    const byName = new Map(graph.nodes.map((node) => [node.name, node]));
+    const rows = [];
+    let widest = 0;
+    for (const layer of graph.layers) {
+      const nodes = layer.nodes.map((name) => byName.get(name)).filter(Boolean);
+      let width = 0;
+      let site = null;
+      const sized = nodes.map((node) => {
+        // Wide enough for whichever of the two lines in the box is the longer.
+        const text = Math.max(node.label.length * 8, topoNodeSub(node).length * 6.2);
+        const w = Math.max(TOPO.minNodeWidth, text + 28);
+        if (width) width += TOPO.gapX;
+        if (site !== null && node.site !== site) width += TOPO.siteGap - TOPO.gapX;
+        site = node.site;
+        const placed = { node, w, offset: width };
+        width += w;
+        return placed;
+      });
+      widest = Math.max(widest, width);
+      rows.push({ layer, nodes: sized, width });
+    }
+
+    const canvasWidth = TOPO.padLeft + widest + TOPO.padRight;
+    const positions = new Map();
+    rows.forEach((row, index) => {
+      const y = TOPO.padY + index * TOPO.rowHeight;
+      const start = TOPO.padLeft + (widest - row.width) / 2;
+      row.y = y;
+      for (const placed of row.nodes) {
+        const x = start + placed.offset;
+        positions.set(placed.node.name, {
+          x,
+          y,
+          w: placed.w,
+          h: TOPO.nodeHeight,
+          cx: x + placed.w / 2,
+          cy: y + TOPO.nodeHeight / 2,
+        });
+      }
+    });
+
+    return {
+      rows,
+      positions,
+      width: canvasWidth,
+      height: TOPO.padY * 2 + rows.length * TOPO.rowHeight,
+    };
+  }
+
+  function renderTopology(graph) {
+    dom.topoCanvas.replaceChildren();
+    renderTopoLegend(graph);
+    dom.topoStats.textContent = topoSummary(graph);
+    if (!graph.nodes.length) {
+      const empty = document.createElement("p");
+      empty.className = "empty";
+      empty.textContent = "No nodes are streaming LLDP yet.";
+      dom.topoCanvas.append(empty);
+      return;
+    }
+
+    const layout = layoutTopology(graph);
+    const svg = svgEl("svg", {
+      class: "topo-svg",
+      viewBox: `0 0 ${layout.width} ${layout.height}`,
+      width: layout.width,
+      height: layout.height,
+      role: "img",
+      "aria-label": "Fabric topology",
+    });
+
+    const bands = svgEl("g", { class: "topo-bands" });
+    for (const row of layout.rows) {
+      bands.append(
+        svgEl("rect", {
+          class: "topo-band",
+          x: 8,
+          y: row.y - 18,
+          width: layout.width - 16,
+          height: TOPO.nodeHeight + 36,
+          rx: 10,
+        })
+      );
+      const label = svgEl("text", {
+        class: "topo-band-label",
+        x: 20,
+        y: row.y + TOPO.nodeHeight / 2 + 4,
+      });
+      label.textContent = row.layer.label;
+      bands.append(label);
+    }
+    svg.append(bands);
+
+    svg.append(renderTopoLinks(graph, layout));
+    svg.append(renderTopoNodes(graph, layout));
+    dom.topoCanvas.append(svg);
+
+    svg.addEventListener("mouseover", (event) => {
+      const target = event.target.closest("[data-node]");
+      highlightTopo(target ? target.dataset.node : null);
+    });
+    svg.addEventListener("mouseleave", () => highlightTopo(null));
+    svg.addEventListener("click", (event) => {
+      const node = event.target.closest("[data-node]");
+      const link = event.target.closest("[data-link]");
+      if (node) selectTopo({ kind: "node", id: node.dataset.node });
+      else if (link) selectTopo({ kind: "link", id: link.dataset.link });
+      else selectTopo(null);
+    });
+
+    applyTopoSelection();
+  }
+
+  function renderTopoLinks(graph, layout) {
+    const group = svgEl("g", { class: "topo-links" });
+    for (const link of graph.links) {
+      const a = layout.positions.get(link.a);
+      const b = layout.positions.get(link.b);
+      if (!a || !b) continue;
+      const id = `${link.a}\u0000${link.b}`;
+      const aIsTop = a.y <= b.y;
+      const [top, bottom] = aIsTop ? [a, b] : [b, a];
+      const shape = link.intra_layer
+        ? svgEl("path", {
+            // An arc under the tier, so a DCGW mesh or a spine pair does not
+            // draw a line straight through the nodes between its ends.
+            d: `M ${a.cx} ${a.y + a.h} Q ${(a.cx + b.cx) / 2} ${a.y + a.h + 46} ${b.cx} ${b.y + b.h}`,
+            fill: "none",
+          })
+        : svgEl("line", {
+            x1: top.cx,
+            y1: top.y + top.h,
+            x2: bottom.cx,
+            y2: bottom.y,
+          });
+      shape.setAttribute(
+        "class",
+        `topo-link link-${link.state}${link.access ? " is-access" : ""}`
+      );
+      shape.setAttribute("data-link", id);
+      shape.setAttribute("data-a", link.a);
+      shape.setAttribute("data-b", link.b);
+      const title = svgEl("title");
+      title.textContent = topoLinkTitle(link);
+      shape.append(title);
+      group.append(shape);
+
+      if (link.count > 1) {
+        const badge = svgEl("text", {
+          class: "topo-link-count",
+          x: (a.cx + b.cx) / 2,
+          y: (a.cy + b.cy) / 2,
+          "text-anchor": "middle",
+        });
+        badge.textContent = `${link.count}\u00d7`;
+        group.append(badge);
+      }
+      // Only a single cable can be labelled without the two ends colliding;
+      // a bundle shows its size instead, and its ports in the detail panel.
+      if (dom.topoPortLabels.checked && !link.intra_layer && link.count === 1) {
+        const ports = link.ports[0];
+        group.append(
+          portLabel(top, bottom, 0.18, shortPort(aIsTop ? ports.a_port : ports.b_port)),
+          portLabel(top, bottom, 0.82, shortPort(aIsTop ? ports.b_port : ports.a_port))
+        );
+      }
+    }
+    return group;
+  }
+
+  /** A port name placed a fraction of the way down a link. */
+  function portLabel(top, bottom, fraction, text) {
+    const label = svgEl("text", {
+      class: "topo-port",
+      x: top.cx + (bottom.cx - top.cx) * fraction,
+      y: top.y + top.h + (bottom.y - top.y - top.h) * fraction,
+      "text-anchor": "middle",
+    });
+    label.textContent = text;
+    return label;
+  }
+
+  function renderTopoNodes(graph, layout) {
+    const group = svgEl("g", { class: "topo-nodes" });
+    for (const node of graph.nodes) {
+      const box = layout.positions.get(node.name);
+      if (!box) continue;
+      const cell = svgEl("g", {
+        class: `topo-node role-${node.role}${node.connected ? "" : " is-down"}`,
+        "data-node": node.name,
+        tabindex: "0",
+      });
+      cell.append(
+        svgEl("rect", { x: box.x, y: box.y, width: box.w, height: box.h, rx: 8 })
+      );
+      const label = svgEl("text", {
+        class: "topo-node-label",
+        x: box.cx,
+        y: box.y + 20,
+        "text-anchor": "middle",
+      });
+      label.textContent = node.label;
+      const sub = svgEl("text", {
+        class: "topo-node-sub",
+        x: box.cx,
+        y: box.y + 35,
+        "text-anchor": "middle",
+      });
+      sub.textContent = topoNodeSub(node);
+      const title = svgEl("title");
+      title.textContent = topoNodeTitle(node);
+      cell.append(label, sub, title);
+      group.append(cell);
+    }
+    return group;
+  }
+
+  function topoNodeSub(node) {
+    if (isTopoAttached(node)) {
+      // Being multi-homed is said before what is carried: the leaves under the
+      // box are the point of it being a single box.
+      const leaves = new Set(node.attachments.map((a) => a.node)).size;
+      if (leaves > 1) return `multi-homed, ${leaves} leaves`;
+      const services = node.services || [];
+      if (services.length === 1) return services[0];
+      if (services.length) return `${services.length} services`;
+      return `${node.ports} port(s)`;
+    }
+    if (node.mac_vrfs || node.ip_vrfs) {
+      const parts = [];
+      if (node.mac_vrfs) parts.push(`${node.mac_vrfs} mac`);
+      if (node.ip_vrfs) parts.push(`${node.ip_vrfs} ip`);
+      if (node.stitched) parts.push(`${node.stitched} gw`);
+      return parts.join(" · ");
+    }
+    return node.site || ROLE_LABELS[node.role] || node.role;
+  }
+
+  /** Whether a node is drawn from its attachments: a client or a segment. */
+  function isTopoAttached(node) {
+    return node.role === "client" || node.role === "segment";
+  }
+
+  function topoNodeTitle(node) {
+    const lines = [node.name, ROLE_LABELS[node.role] || node.role];
+    if (isTopoAttached(node)) {
+      for (const attachment of node.attachments || []) {
+        lines.push(attachmentText(attachment));
+      }
+      return lines.join(" - ");
+    }
+    if (node.site) lines.push(`site ${node.site}`);
+    if (node.mac_vrfs || node.ip_vrfs) {
+      lines.push(`${node.mac_vrfs} mac-vrf, ${node.ip_vrfs} ip-vrf`);
+    }
+    if (node.stitched) lines.push(`${node.stitched} stitched service(s)`);
+    if (node.clients) lines.push(`${node.clients} client(s)`);
+    if (node.error) lines.push(node.error);
+    return lines.join(" - ");
+  }
+
+  /** One attachment as a line: where it lands and what it carries. */
+  function attachmentText(attachment) {
+    const parts = [`${attachment.node} ${shortPort(attachment.subinterface)}`];
+    if (attachment.service) parts.push(attachment.service);
+    if (attachment.vlan) parts.push(`vlan ${attachment.vlan}`);
+    if (attachment.ip) parts.push(attachment.ip);
+    return parts.join(" · ");
+  }
+
+  function topoLinkTitle(link) {
+    const ports = link.ports
+      .map((pair) => cableText(pair.a_port, pair.b_port, "↔"))
+      .join(", ");
+    return `${link.a} ↔ ${link.b}${ports ? " (" + ports + ")" : ""}`;
+  }
+
+  /** Both ends of a cable, or the one end of it a client does not report. */
+  function cableText(near, far, arrow) {
+    if (!far) return shortPort(near);
+    if (!near) return shortPort(far);
+    return `${shortPort(near)} ${arrow} ${shortPort(far)}`;
+  }
+
+  function topoSummary(graph) {
+    const parts = [`${graph.nodes.length} nodes`, `${graph.links.length} links`];
+    if (graph.unresolved.length) {
+      parts.push(`${graph.unresolved.length} neighbour(s) outside the inventory`);
+    }
+    return parts.join(" · ");
+  }
+
+  function renderTopoLegend(graph) {
+    dom.topoLegend.replaceChildren();
+    const order = ["client", "segment", "leaf", "spine", "dcgw", "core", "unknown", "external"];
+    for (const role of order) {
+      const count = graph.roles[role];
+      if (!count) continue;
+      const chip = document.createElement("span");
+      chip.className = `topo-chip role-${role}`;
+      const swatch = document.createElement("span");
+      swatch.className = "topo-swatch";
+      const text = document.createElement("span");
+      text.textContent = `${ROLE_LABELS[role]} ${count}`;
+      chip.append(swatch, text);
+      dom.topoLegend.append(chip);
+    }
+  }
+
+  /** Dim everything that is not *name* and what it is cabled to. */
+  function highlightTopo(name) {
+    const svg = dom.topoCanvas.querySelector(".topo-svg");
+    if (!svg) return;
+    svg.querySelectorAll(".is-hot").forEach((node) => node.classList.remove("is-hot"));
+    if (!name) {
+      svg.classList.toggle("is-focused", Boolean(state.topoSelection));
+      if (state.topoSelection) applyTopoSelection();
+      return;
+    }
+    svg.classList.add("is-focused");
+    markTopoNode(svg, name);
+  }
+
+  function markTopoNode(svg, name) {
+    const node = svg.querySelector(`[data-node="${CSS.escape(name)}"]`);
+    if (node) node.classList.add("is-hot");
+    svg
+      .querySelectorAll(`[data-a="${CSS.escape(name)}"], [data-b="${CSS.escape(name)}"]`)
+      .forEach((link) => {
+        link.classList.add("is-hot");
+        const peer = link.dataset.a === name ? link.dataset.b : link.dataset.a;
+        const box = svg.querySelector(`[data-node="${CSS.escape(peer)}"]`);
+        if (box) box.classList.add("is-hot");
+      });
+  }
+
+  function selectTopo(selection) {
+    state.topoSelection = selection;
+    applyTopoSelection();
+  }
+
+  function applyTopoSelection() {
+    const svg = dom.topoCanvas.querySelector(".topo-svg");
+    if (!svg) return;
+    svg.querySelectorAll(".is-hot").forEach((node) => node.classList.remove("is-hot"));
+    const selection = state.topoSelection;
+    svg.classList.toggle("is-focused", Boolean(selection));
+    if (!selection) {
+      dom.topoDetail.hidden = true;
+      dom.topoDetail.replaceChildren();
+      return;
+    }
+    if (selection.kind === "node") {
+      markTopoNode(svg, selection.id);
+      renderTopoNodeDetail(selection.id);
+    } else {
+      const link = svg.querySelector(`[data-link="${CSS.escape(selection.id)}"]`);
+      if (link) {
+        link.classList.add("is-hot");
+        for (const end of [link.dataset.a, link.dataset.b]) {
+          const box = svg.querySelector(`[data-node="${CSS.escape(end)}"]`);
+          if (box) box.classList.add("is-hot");
+        }
+      }
+      renderTopoLinkDetail(selection.id);
+    }
+  }
+
+  function topoDetailShell(title, subtitle) {
+    dom.topoDetail.replaceChildren();
+    dom.topoDetail.hidden = false;
+    const head = document.createElement("header");
+    const heading = document.createElement("h2");
+    heading.textContent = title;
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "btn btn-ghost";
+    close.textContent = "✕";
+    close.title = "Close";
+    close.addEventListener("click", () => selectTopo(null));
+    head.append(heading, close);
+    dom.topoDetail.append(head);
+    if (subtitle) {
+      const sub = document.createElement("p");
+      sub.className = "muted";
+      sub.textContent = subtitle;
+      dom.topoDetail.append(sub);
+    }
+    return dom.topoDetail;
+  }
+
+  function topoDetailRow(term, description) {
+    const row = document.createElement("div");
+    row.className = "topo-detail-row";
+    const label = document.createElement("span");
+    label.className = "muted";
+    label.textContent = term;
+    const value = document.createElement("span");
+    value.textContent = description;
+    row.append(label, value);
+    return row;
+  }
+
+  function renderTopoNodeDetail(name) {
+    const graph = state.topology;
+    if (!graph) return;
+    const node = graph.nodes.find((n) => n.name === name);
+    if (!node) {
+      // The node went away between two polls; drop the selection with it.
+      selectTopo(null);
+      return;
+    }
+    if (isTopoAttached(node)) {
+      renderTopoAttachedDetail(node, graph);
+      return;
+    }
+    const panel = topoDetailShell(node.label, node.name === node.label ? "" : node.name);
+    panel.append(topoDetailRow("role", ROLE_LABELS[node.role] || node.role));
+    if (node.site) panel.append(topoDetailRow("site", node.site));
+    panel.append(
+      topoDetailRow("services", `${node.mac_vrfs} mac-vrf · ${node.ip_vrfs} ip-vrf`)
+    );
+    if (node.stitched) {
+      panel.append(topoDetailRow("stitched", `${node.stitched} service(s), two bgp-vpn instances`));
+    }
+    if (node.clients) panel.append(topoDetailRow("clients", String(node.clients)));
+    if (node.error) panel.append(topoDetailRow("error", node.error));
+
+    const links = graph.links.filter((l) => l.a === name || l.b === name);
+    const heading = document.createElement("h3");
+    heading.textContent = `${links.length} link(s)`;
+    panel.append(heading);
+    const list = document.createElement("ul");
+    list.className = "topo-peer-list";
+    for (const link of links) {
+      const peer = link.a === name ? link.b : link.a;
+      const item = document.createElement("li");
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "topo-peer";
+      const peerNode = graph.nodes.find((n) => n.name === peer);
+      const title = document.createElement("span");
+      title.textContent = peerNode ? peerNode.label : peer;
+      const ports = document.createElement("span");
+      ports.className = "muted";
+      ports.textContent = link.ports
+        .map((pair) =>
+          link.a === name
+            ? cableText(pair.a_port, pair.b_port, "→")
+            : cableText(pair.b_port, pair.a_port, "→")
+        )
+        .join(", ");
+      button.append(title, ports);
+      button.addEventListener("click", () => selectTopo({ kind: "node", id: peer }));
+      item.append(button);
+      list.append(item);
+    }
+    panel.append(list);
+  }
+
+  /** A client or a segment is its attachments: where it lands, in which service. */
+  function renderTopoAttachedDetail(node, graph) {
+    const label = (name) => {
+      const peer = graph.nodes.find((n) => n.name === name);
+      return peer ? peer.label : name;
+    };
+    const panel = topoDetailShell(node.label, node.peers.map(label).join(", "));
+    panel.append(topoDetailRow("role", ROLE_LABELS[node.role] || node.role));
+    if (node.advertised) panel.append(topoDetailRow("lldp name", node.advertised));
+    if ((node.names || []).length) {
+      panel.append(topoDetailRow("configured as", node.names.join(" · ")));
+    }
+    if (node.site) panel.append(topoDetailRow("site", node.site));
+    const kinds = [...new Set(node.attachments.map((a) => a.kind))];
+    if (kinds.length) panel.append(topoDetailRow("attached", kinds.join(" · ")));
+    if (node.esi) panel.append(topoDetailRow("esi", node.esi));
+
+    const heading = document.createElement("h3");
+    heading.textContent = `${node.attachments.length} attachment(s)`;
+    panel.append(heading);
+    const list = document.createElement("ul");
+    list.className = "topo-peer-list";
+    for (const attachment of node.attachments) {
+      const item = document.createElement("li");
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "topo-peer";
+      const title = document.createElement("span");
+      title.textContent = `${label(attachment.node)} ${shortPort(attachment.subinterface)}`;
+      const detail = document.createElement("span");
+      detail.className = "muted";
+      const parts = [attachment.service];
+      if (attachment.vlan) parts.push(`vlan ${attachment.vlan}`);
+      if (attachment.ip) parts.push(attachment.ip);
+      if (attachment.state) parts.push(attachment.state);
+      detail.textContent = parts.filter(Boolean).join(" · ");
+      button.append(title, detail);
+      button.addEventListener("click", () =>
+        selectTopo({ kind: "node", id: attachment.node })
+      );
+      item.append(button);
+      list.append(item);
+    }
+    panel.append(list);
+  }
+
+  function renderTopoLinkDetail(id) {
+    const graph = state.topology;
+    if (!graph) return;
+    const [a, b] = id.split("\u0000");
+    const link = graph.links.find((l) => l.a === a && l.b === b);
+    if (!link) {
+      selectTopo(null);
+      return;
+    }
+    const label = (name) => {
+      const node = graph.nodes.find((n) => n.name === name);
+      return node ? node.label : name;
+    };
+    const panel = topoDetailShell(`${label(a)} ↔ ${label(b)}`, "");
+    panel.append(topoDetailRow("state", link.state));
+    panel.append(topoDetailRow("cables", String(link.count)));
+    const list = document.createElement("ul");
+    list.className = "topo-peer-list";
+    for (const pair of link.ports) {
+      const item = document.createElement("li");
+      item.className = "topo-cable";
+      item.textContent = cableText(pair.a_port, pair.b_port, "↔");
+      list.append(item);
+    }
+    panel.append(list);
+  }
+
   /* ---------------------------------------------------------- page history */
 
   function currentNavSnap() {
@@ -521,6 +1128,10 @@
       clearInterval(overviewTimer);
       overviewTimer = null;
     }
+    if (topologyTimer) {
+      clearInterval(topologyTimer);
+      topologyTimer = null;
+    }
 
     loadReportPreferences();
     if (snap) {
@@ -532,21 +1143,31 @@
     updateFilterUI();
     renderReportList();
 
-    if (report.name === "overview") {
+    if (isPanelReport(report.name)) {
+      // A panel draws itself from its own endpoint instead of a table stream.
       dom.tableWrap.hidden = true;
       dom.servicesTreeView.hidden = true;
       dom.viewModeBtn.hidden = true;
       dom.columnsBtn.hidden = true;
       dom.exportBtn.hidden = true;
-      dom.overviewDashboard.hidden = false;
+      dom.overviewDashboard.hidden = report.name !== "overview";
+      dom.topologyView.hidden = report.name !== "topology";
       if (state.source) {
         state.source.close();
         state.source = null;
       }
-      loadOverview();
-      overviewTimer = setInterval(loadOverview, 5000);
+      if (report.name === "overview") {
+        loadOverview();
+        overviewTimer = setInterval(loadOverview, 5000);
+      } else {
+        state.topoKey = "";
+        state.topoSelection = null;
+        loadTopology();
+        topologyTimer = setInterval(loadTopology, 5000);
+      }
     } else {
       dom.overviewDashboard.hidden = true;
+      dom.topologyView.hidden = true;
       dom.columnsBtn.hidden = false;
       dom.exportBtn.hidden = false;
       if (["bridge_domains", "services", "routers"].includes(report.name)) {
@@ -576,7 +1197,7 @@
       state.source.close();
       state.source = null;
     }
-    if (!state.report || state.report.name === "overview" || state.paused) return;
+    if (!state.report || isPanelReport(state.report.name) || state.paused) return;
     const params = new URLSearchParams({ refresh: dom.refresh.value });
     const inv = dom.invFilter.value.trim();
     if (inv) params.set("inv_filter", inv);
@@ -1876,6 +2497,8 @@
   }
 
   function renderBody() {
+    // Overview and Topology own the main area; a table would be drawn over them.
+    if (state.report && isPanelReport(state.report.name)) return;
     const rows = filteredRows();
 
     if (
@@ -2086,7 +2709,12 @@
     () => {
       saveReportPreferences();
       updateFilterUI();
-      connect();
+      if (state.report && state.report.name === "topology") {
+        state.topoKey = "";
+        loadTopology();
+      } else {
+        connect();
+      }
     }
   );
   dom.refresh.addEventListener(
@@ -2131,9 +2759,20 @@
       if (state.source) state.source.close();
       state.source = null;
       setLive("paused", "paused");
+    } else if (state.report && state.report.name === "topology") {
+      loadTopology();
     } else {
       connect();
     }
+  });
+
+  dom.topoPortLabels.addEventListener("change", () => {
+    try {
+      localStorage.setItem("fcli-topo-ports", dom.topoPortLabels.checked ? "1" : "");
+    } catch (_err) {
+      /* storage may be unavailable */
+    }
+    if (state.topology) renderTopology(state.topology);
   });
 
   dom.columnsBtn.addEventListener("click", () => {
@@ -2171,6 +2810,7 @@
   try {
     const stored = localStorage.getItem("fcli-theme");
     if (stored) document.documentElement.dataset.theme = stored;
+    dom.topoPortLabels.checked = Boolean(localStorage.getItem("fcli-topo-ports"));
   } catch (_err) {
     /* storage may be unavailable */
   }

--- a/nornir_srl/server/static/index.html
+++ b/nornir_srl/server/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>fcli - SR Linux fabric</title>
-    <link rel="stylesheet" href="/static/style.css" />
+    <link rel="stylesheet" href="/static/style.css?v=__ASSETS__" />
     <link
       rel="icon"
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f766e'/%3E%3Ctext x='16' y='23' font-family='monospace' font-size='18' fill='white' text-anchor='middle'%3Ef%3C/text%3E%3C/svg%3E"
@@ -178,6 +178,21 @@
           </div>
         </div>
 
+        <div id="topology-view" class="topo-wrap" hidden>
+          <div class="topo-bar">
+            <div id="topo-legend" class="topo-legend"></div>
+            <label class="field topo-ports">
+              <input id="topo-port-labels" type="checkbox" />
+              <span class="muted">port labels</span>
+            </label>
+            <span id="topo-stats" class="muted"></span>
+          </div>
+          <div class="topo-body">
+            <div id="topo-canvas" class="topo-canvas"></div>
+            <aside id="topo-detail" class="topo-detail" hidden></aside>
+          </div>
+        </div>
+
         <div id="services-tree-view" class="services-tree-wrap" hidden></div>
 
         <div class="table-wrap" id="table-wrap">
@@ -198,6 +213,6 @@
         </footer>
       </main>
     </div>
-    <script src="/static/app.js"></script>
+    <script src="/static/app.js?v=__ASSETS__"></script>
   </body>
 </html>

--- a/nornir_srl/server/static/style.css
+++ b/nornir_srl/server/static/style.css
@@ -1192,3 +1192,287 @@ button.pill-jump:focus-visible {
   animation: pulse-highlight 1.5s ease-in-out 2;
   border-color: var(--accent) !important;
 }
+
+/* ------------------------------------------------------------- Topology */
+
+:root {
+  --role-client: #be185d;
+  --role-segment: #9333ea;
+  --role-leaf: #0f766e;
+  --role-spine: #2563eb;
+  --role-dcgw: #b45309;
+  --role-core: #7c3aed;
+  --role-unknown: #667085;
+  --role-external: #94a3b8;
+}
+
+[data-theme="dark"] {
+  --role-client: #f472b6;
+  --role-segment: #c4b5fd;
+  --role-leaf: #2dd4bf;
+  --role-spine: #60a5fa;
+  --role-dcgw: #fbbf24;
+  --role-core: #c084fc;
+  --role-unknown: #8b95a3;
+  --role-external: #64748b;
+}
+
+.topo-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.topo-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+  flex-wrap: wrap;
+}
+
+.topo-legend {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.topo-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.topo-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background: currentColor;
+}
+
+.topo-chip.role-client .topo-swatch { color: var(--role-client); }
+.topo-chip.role-segment .topo-swatch { color: var(--role-segment); }
+.topo-chip.role-leaf .topo-swatch { color: var(--role-leaf); }
+.topo-chip.role-spine .topo-swatch { color: var(--role-spine); }
+.topo-chip.role-dcgw .topo-swatch { color: var(--role-dcgw); }
+.topo-chip.role-core .topo-swatch { color: var(--role-core); }
+.topo-chip.role-unknown .topo-swatch { color: var(--role-unknown); }
+.topo-chip.role-external .topo-swatch { color: var(--role-external); }
+
+.topo-ports {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.topo-bar .topo-ports + .muted,
+.topo-bar #topo-stats {
+  margin-left: auto;
+  font-size: 12px;
+}
+
+.topo-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.topo-canvas {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  padding: 18px;
+}
+
+.topo-svg {
+  max-width: 100%;
+  height: auto;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.topo-band {
+  fill: var(--panel);
+  stroke: var(--border);
+  stroke-dasharray: 3 4;
+}
+
+.topo-band-label {
+  fill: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.topo-link {
+  stroke: var(--border);
+  stroke-width: 1.6;
+  cursor: pointer;
+}
+
+.topo-link.link-up {
+  stroke: var(--ok);
+}
+
+.topo-link.link-down {
+  stroke: var(--err);
+  stroke-dasharray: 5 4;
+}
+
+/* A cable to a client is thinner: the fabric is what the eye should follow. */
+.topo-link.is-access {
+  stroke-width: 1.1;
+  opacity: 0.75;
+}
+
+.topo-link-count,
+.topo-port {
+  fill: var(--muted);
+  font-size: 10px;
+  font-family: var(--mono);
+  pointer-events: none;
+}
+
+.topo-node {
+  cursor: pointer;
+}
+
+.topo-node rect {
+  fill: var(--panel);
+  stroke: var(--role-unknown);
+  stroke-width: 1.5;
+}
+
+.topo-node.role-client rect { stroke: var(--role-client); fill: var(--panel-2); }
+.topo-node.role-segment rect { stroke: var(--role-segment); fill: var(--panel-2); }
+.topo-node.role-leaf rect { stroke: var(--role-leaf); }
+.topo-node.role-spine rect { stroke: var(--role-spine); }
+.topo-node.role-dcgw rect { stroke: var(--role-dcgw); stroke-width: 2; }
+.topo-node.role-core rect { stroke: var(--role-core); }
+.topo-node.role-external rect { stroke: var(--role-external); stroke-dasharray: 4 3; }
+
+.topo-node.is-down rect {
+  stroke: var(--err);
+  stroke-dasharray: 4 3;
+}
+
+.topo-node-label {
+  fill: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.topo-node-sub {
+  fill: var(--muted);
+  font-size: 10px;
+  font-family: var(--mono);
+}
+
+/* Hovering or selecting a node pushes everything it is not cabled to back. */
+.topo-svg.is-focused .topo-node,
+.topo-svg.is-focused .topo-link {
+  opacity: 0.25;
+  transition: opacity 0.12s ease;
+}
+
+.topo-svg.is-focused .topo-node.is-hot,
+.topo-svg.is-focused .topo-link.is-hot {
+  opacity: 1;
+}
+
+.topo-link.is-hot {
+  stroke-width: 2.6;
+}
+
+.topo-node.is-hot rect {
+  filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.25));
+}
+
+.topo-detail {
+  width: 290px;
+  flex: none;
+  border-left: 1px solid var(--border);
+  background: var(--panel);
+  padding: 14px 16px;
+  overflow: auto;
+}
+
+.topo-detail header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.topo-detail h2 {
+  margin: 0;
+  font-size: 15px;
+  font-family: var(--mono);
+}
+
+.topo-detail header .btn {
+  margin-left: auto;
+  padding: 2px 8px;
+}
+
+.topo-detail h3 {
+  margin: 16px 0 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.topo-detail-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 3px 0;
+  font-size: 12px;
+}
+
+.topo-peer-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.topo-peer {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 4px 6px;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.topo-peer:hover {
+  background: var(--panel-2);
+  border-color: var(--border);
+}
+
+.topo-peer .muted {
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.topo-cable {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 3px 6px;
+}

--- a/nornir_srl/server/store.py
+++ b/nornir_srl/server/store.py
@@ -17,6 +17,7 @@ from ..reports import ReportSpec, SubscriptionSpec, get_report
 from ..rows import clean_columns, flatten
 from .devices import CachedDevice, RecordingDevice
 from .stream import HostStream
+from .topology import build_topology, node_facts
 
 logger = logging.getLogger(__name__)
 
@@ -582,9 +583,57 @@ class FabricStore:
             },
         }
 
+    def topology(self, inv_filter: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        """The fabric graph: LLDP adjacencies, with a tier per node.
+
+        Nodes that are down or have not streamed anything yet are still part of
+        the answer, as unclassified ones - a topology missing the node that
+        failed would be the opposite of useful.
+        """
+        started = time.time()
+        names = self._targets(inv_filter)
+        self._heal_connections(names)
+        try:
+            self.activate(get_report("topology"), names)
+        except Exception as exc:  # noqa: BLE001 - the graph still renders
+            logger.warning("activating the topology report failed: %s", exc)
+
+        hosts = {h["name"]: h for h in self.inventory()}
+        with self._lock:
+            streams = {n: self._streams[n] for n in names if n in self._streams}
+
+        facts = []
+        for name in names:
+            host = self.nornir.inventory.hosts.get(name)
+            stream = streams.get(name)
+            status = hosts.get(name, {})
+            facts.append(
+                node_facts(
+                    name,
+                    hostname=(host.hostname if host else "") or name,
+                    labels=(host.data if host else None) or {},
+                    # Taken under this node's lock only, so summarizing the
+                    # fabric does not stall the renders running on the others.
+                    snapshot=stream.snapshot_roots(_TOPOLOGY_ROOTS) if stream else None,
+                    connected=bool(status.get("connected")),
+                    error=status.get("error"),
+                )
+            )
+
+        graph = build_topology(facts)
+        graph["generated"] = started
+        graph["render_ms"] = round((time.time() - started) * 1000, 1)
+        graph["oldest_update"] = _oldest_update(list(streams.values()))
+        return graph
+
 
 #: Tree roots the overview summarizes.
 _OVERVIEW_ROOTS: Tuple[str, ...] = ("interface", "network-instance")
+
+#: Tree roots the topology is inferred from: LLDP and the host-name under
+#: ``system``, the services under ``network-instance``, port states under
+#: ``interface``.
+_TOPOLOGY_ROOTS: Tuple[str, ...] = ("system", "network-instance", "interface")
 
 #: Cap on cached rendered tables, evicting the oldest beyond it.
 _MAX_CACHED_TABLES = 256

--- a/nornir_srl/server/topology.py
+++ b/nornir_srl/server/topology.py
@@ -1,0 +1,886 @@
+"""The fabric topology, inferred from LLDP adjacencies and where services live.
+
+Nothing tells fcli what a node is. The inventory may carry role labels or
+nothing at all, and a label is a claim about intent rather than about what the
+node runs. So the tier of a node is derived from the two things the fabric
+itself reports: the services configured on it, and who its LLDP neighbours are.
+
+* A node with mac-vrfs, and optionally ip-vrfs, is a **leaf**: the tier where a
+  service meets a port.
+* A node whose services carry two or more enabled ``bgp-vpn`` instances is a
+  **DCGW**. The second instance is the WAN side of a stitched service, which
+  only a gateway out of the DC has.
+* A node with no mac-vrf and no ip-vrf that sees two or more leaves is a
+  **spine**: it interconnects the leaves without terminating anything.
+* Any other node without services is **core**: WAN P/PE routers and
+  super-spines, which transit the fabric but attach to no leaf of it.
+
+Below all of them sit the **clients**, which are not nodes of the inventory at
+all but the far end of what a service is configured towards: a bridged
+subinterface of a mac-vrf, or a routed port of an ip-vrf, on a port that faces
+nothing else we know of. A client is identified by the name it advertises over
+LLDP, or failing that by the ESI of the ethernet-segment its port is in, so that
+a multi-homed one is a single box spanning its leaves.
+
+Between the two sit the **ethernet-segments**. A multi-homed client does not
+reach its leaves over a cable each but over one bundle, which is a configured
+object in its own right: it has a name, an ESI that every leaf on it agrees on,
+and it is where multi-homing goes wrong. So it is drawn as a tier of its own,
+and the client hangs off the bundle rather than off each leaf.
+
+The result is drawn one tier per layer, clients at the bottom and the WAN on top.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+#: The tiers of a fabric, bottom up, as ``(layer, role, label)``.
+LAYERS: Tuple[Tuple[int, str, str], ...] = (
+    (0, "client", "Clients"),
+    (1, "segment", "Ethernet segments"),
+    (2, "edge", "Edge / unclassified"),
+    (3, "leaf", "Leaves"),
+    (4, "spine", "Spines"),
+    (5, "dcgw", "DC gateways"),
+    (6, "core", "WAN / core"),
+)
+
+#: What an ethernet-segment node is named, so that it cannot collide with the
+#: client on it - which, having nothing else to go by, is named after the ESI.
+_SEGMENT_PREFIX = "es:"
+
+#: Roles that share the layer holding whatever we could not place: nodes that
+#: have told us nothing yet, and nodes we only know from someone's LLDP.
+_EDGE_ROLES = ("unknown", "external")
+
+_LAYER_OF = {role: layer for layer, role, _ in LAYERS}
+_LAYER_OF.update({role: _LAYER_OF["edge"] for role in _EDGE_ROLES})
+_LAYER_LABEL = {layer: label for layer, _, label in LAYERS}
+
+_UP_STATES = frozenset({"up", "enable", "enabled", "active"})
+_DOWN_STATES = frozenset({"down", "disable", "disabled"})
+
+#: Ports whose LLDP says nothing about the fabric. Every node of a lab hangs off
+#: the same management bridge and sees all the others on it, which would draw a
+#: full mesh over the topology and leave every node with the same neighbours.
+_OUT_OF_BAND = ("mgmt",)
+
+#: Interfaces a service binds that no client can be on. An IRB is the routed
+#: side of a bridge domain, a loopback and ``system0`` are the node's own
+#: addresses, and the management port is out of band.
+_VIRTUAL_PORTS = ("irb", "lo", "system", "mgmt")
+
+
+@dataclass
+class Adjacency:
+    """One LLDP neighbour, seen on one local port."""
+
+    local_port: str
+    #: The system-name the neighbour advertises, which is not the name the
+    #: inventory knows it by.
+    peer: str
+    peer_port: str = ""
+    oper_state: str = ""
+
+
+@dataclass
+class Segment:
+    """An ethernet-segment: one cable bundle, seen from each node it lands on.
+
+    The ESI is the same on every node a multi-homed client is attached to, and
+    for a client that runs no LLDP it is the only thing that says the two lags
+    are one host rather than two.
+    """
+
+    name: str
+    esi: str
+
+
+@dataclass
+class Attachment:
+    """One client-facing subinterface: where a service meets a customer port."""
+
+    subinterface: str
+    #: The port the subinterface is on. LLDP reports a neighbour against the
+    #: port, and it is what makes several vlans of one cable a single client.
+    port: str
+    #: The network-instance the subinterface is bound to.
+    service: str
+    #: ``bridged`` for a member of a mac-vrf, ``routed`` for one of an ip-vrf.
+    kind: str
+    vlan: str = ""
+    ip: str = ""
+    oper_state: str = ""
+
+
+@dataclass
+class NodeFacts:
+    """What one node contributes to the topology."""
+
+    name: str
+    hostname: str = ""
+    system_name: str = ""
+    site: str = ""
+    mac_vrfs: int = 0
+    ip_vrfs: int = 0
+    #: Services with two or more enabled ``bgp-vpn`` instances: the DCGW mark.
+    stitched: int = 0
+    #: Whether any network-instance state arrived at all, which is what
+    #: separates 'runs no services' from 'has not told us anything yet'.
+    has_state: bool = False
+    connected: bool = True
+    error: Optional[str] = None
+    adjacencies: List[Adjacency] = field(default_factory=list)
+    #: The service-carrying subinterfaces, before the fabric-facing ones are
+    #: taken out of them - which needs every node's LLDP, so it happens in
+    #: :func:`build_topology` rather than here.
+    attachments: List[Attachment] = field(default_factory=list)
+    #: The ethernet-segment on each port that is in one.
+    segments: Dict[str, Segment] = field(default_factory=dict)
+
+    @property
+    def label(self) -> str:
+        """The short name to draw the node under."""
+        return self.system_name or self.name
+
+
+def node_facts(
+    name: str,
+    *,
+    hostname: str = "",
+    labels: Optional[Dict[str, Any]] = None,
+    snapshot: Optional[Dict[str, Any]] = None,
+    connected: bool = True,
+    error: Optional[str] = None,
+) -> NodeFacts:
+    """Read one node's contribution out of its streamed state.
+
+    *snapshot* is the ``system``, ``network-instance`` and ``interface`` trees as
+    :meth:`~nornir_srl.server.stream.HostStream.snapshot_roots` returns them. A
+    node with nothing streamed yet yields facts that classify as ``unknown``
+    rather than as a node without services.
+    """
+    labels = labels or {}
+    snapshot = snapshot or {}
+    system = _branch(snapshot, "system")
+    facts = NodeFacts(
+        name=name,
+        hostname=hostname or name,
+        system_name=str(_branch(system, "name").get("host-name") or ""),
+        site=str(labels.get("site") or ""),
+        connected=connected,
+        error=error,
+    )
+
+    instances = snapshot.get("network-instance")
+    if isinstance(instances, list) and instances:
+        facts.has_state = True
+        details = _subinterface_details(snapshot)
+        for instance in instances:
+            if not isinstance(instance, dict):
+                continue
+            ni_type = _norm(instance.get("type"))
+            if ni_type == "mac-vrf":
+                facts.mac_vrfs += 1
+                kind = "bridged"
+            elif ni_type in ("ip-vrf", "vrf") and str(instance.get("name", "")) != "mgmt":
+                facts.ip_vrfs += 1
+                kind = "routed"
+            else:
+                continue
+            facts.attachments.extend(_attachments(instance, kind, details))
+            if _is_stitched(instance):
+                facts.stitched += 1
+
+    facts.adjacencies = _adjacencies(system, _interface_states(snapshot))
+    facts.segments = _segments(system)
+    return facts
+
+
+def build_topology(facts: Iterable[NodeFacts]) -> Dict[str, Any]:
+    """Turn per-node facts into the nodes, links and layers of the fabric."""
+    nodes = list(facts)
+    aliases = _alias_index(nodes)
+
+    peers: Dict[str, Set[str]] = {f.name: set() for f in nodes}
+    #: Neighbours that match no node of the inventory, by advertised name.
+    outside: Dict[str, Set[str]] = {}
+    links: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    #: The local ports that face a node of the inventory: the fabric itself.
+    fabric_ports: Dict[str, Set[str]] = {f.name: set() for f in nodes}
+    #: What an unmatched neighbour calls itself, per port it was seen on.
+    outside_ports: Dict[Tuple[str, str], str] = {}
+
+    for node in nodes:
+        for adj in node.adjacencies:
+            target = _resolve(adj.peer, aliases)
+            if target == node.name:  # a neighbour on our own name is a loop
+                continue
+            if target is None:
+                target = adj.peer
+                outside.setdefault(target, set()).add(node.name)
+                outside_ports[(node.name, adj.local_port)] = target
+            else:
+                fabric_ports[node.name].add(adj.local_port)
+                peers[node.name].add(target)
+                peers.setdefault(target, set()).add(node.name)
+            _record_link(links, node.name, target, adj)
+
+    # Roles are settled before the clients are added, so that hanging one off a
+    # node can never be what decides which tier the node itself is on.
+    roles = _classify(nodes, peers)
+    clients = _clients(nodes, fabric_ports, outside_ports)
+    segments = _segment_nodes(clients)
+    for client in clients:
+        #: The state of every port of a bundle, per ethernet-segment node.
+        bundles: Dict[str, List[str]] = {}
+        for attachment in client["attachments"]:
+            # A port that is in an ethernet-segment is cabled to the segment
+            # rather than to the client, and the segment down to the client.
+            near = _segment_key(attachment["esi"]) if attachment["esi"] else client["name"]
+            peers[attachment["node"]].add(near)
+            _record_access_link(links, near, attachment)
+            if attachment["esi"]:
+                bundles.setdefault(near, []).append(attachment["state"])
+        for name, states in sorted(bundles.items()):
+            _record_bundle_link(links, name, client["name"], states)
+        # A client that named itself over LLDP is no longer a stray neighbour.
+        outside.pop(client["name"], None)
+
+    counts = _client_counts(clients)
+    payload = [
+        _node_payload(node, roles[node.name], sorted(peers[node.name]), counts.get(node.name, 0))
+        for node in nodes
+    ]
+    payload.extend(
+        _external_payload(name, sorted(seen_by)) for name, seen_by in sorted(outside.items())
+    )
+    payload.extend(segments)
+    payload.extend(clients)
+    payload.sort(key=lambda n: (-n["layer"], n["site"], _row_order(n), n["label"]))
+    layer_of = {node["name"]: node["layer"] for node in payload}
+
+    return {
+        "nodes": payload,
+        "links": [_link_payload(link, layer_of) for _key, link in sorted(links.items())],
+        # Top of the drawing first, and only the tiers this fabric actually has.
+        "layers": _layers(payload),
+        "roles": _role_counts(payload),
+        "sites": sorted({n["site"] for n in payload if n["site"]}),
+        "unresolved": [
+            {"peer": name, "seen_by": sorted(seen_by)} for name, seen_by in sorted(outside.items())
+        ],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# classification
+# --------------------------------------------------------------------------- #
+
+
+def _classify(nodes: List[NodeFacts], peers: Dict[str, Set[str]]) -> Dict[str, str]:
+    """Assign a role to every node, services first and adjacency second."""
+    roles: Dict[str, str] = {}
+    for node in nodes:
+        if node.mac_vrfs or node.ip_vrfs:
+            roles[node.name] = "dcgw" if node.stitched else "leaf"
+        elif not node.has_state:
+            roles[node.name] = "unknown"
+
+    leaves = {name for name, role in roles.items() if role == "leaf"}
+    gateways = {name for name, role in roles.items() if role == "dcgw"}
+    for node in nodes:
+        if node.name in roles:
+            continue
+        attached = peers.get(node.name, set())
+        leaf_peers = len(attached & leaves)
+        # Two leaves is what a spine is for: interconnecting them. A single leaf
+        # counts as well, for a fabric small enough to have only one, but not
+        # when the node also faces a gateway - that is a WAN router hanging off
+        # the fabric rather than a spine inside it.
+        if leaf_peers >= 2 or (leaf_peers == 1 and not attached & gateways):
+            roles[node.name] = "spine"
+        else:
+            roles[node.name] = "core"
+    return roles
+
+
+def _node_payload(node: NodeFacts, role: str, peers: List[str], clients: int) -> Dict[str, Any]:
+    return {
+        "name": node.name,
+        "label": node.label,
+        "role": role,
+        "layer": _LAYER_OF.get(role, _LAYER_OF["edge"]),
+        "site": node.site,
+        "mac_vrfs": node.mac_vrfs,
+        "ip_vrfs": node.ip_vrfs,
+        "stitched": node.stitched,
+        "clients": clients,
+        "peers": peers,
+        "ports": len(node.adjacencies),
+        "connected": node.connected,
+        "error": node.error,
+        "external": False,
+        "attachments": [],
+    }
+
+
+def _external_payload(name: str, seen_by: List[str]) -> Dict[str, Any]:
+    """A node we only know because a neighbour of ours advertises it."""
+    return {
+        "name": name,
+        "label": name,
+        "role": "external",
+        "layer": _LAYER_OF["external"],
+        "site": "",
+        "mac_vrfs": 0,
+        "ip_vrfs": 0,
+        "stitched": 0,
+        "clients": 0,
+        "peers": seen_by,
+        "ports": len(seen_by),
+        "connected": True,
+        "error": None,
+        "external": True,
+        "attachments": [],
+    }
+
+
+def _row_order(node: Dict[str, Any]) -> str:
+    """Clients and segments are drawn under a node they attach to, not by name."""
+    if node["attachments"]:
+        return min(attachment["node"] for attachment in node["attachments"])
+    return ""
+
+
+def _layers(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The occupied tiers, top of the drawing first."""
+    result = []
+    for layer in sorted({n["layer"] for n in nodes}, reverse=True):
+        members = [n["name"] for n in nodes if n["layer"] == layer]
+        result.append(
+            {
+                "index": layer,
+                "label": _LAYER_LABEL.get(layer, f"Layer {layer}"),
+                "nodes": members,
+            }
+        )
+    return result
+
+
+def _role_counts(nodes: List[Dict[str, Any]]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for node in nodes:
+        counts[node["role"]] = counts.get(node["role"], 0) + 1
+    return counts
+
+
+# --------------------------------------------------------------------------- #
+# clients
+# --------------------------------------------------------------------------- #
+
+
+def _clients(
+    nodes: List[NodeFacts],
+    fabric_ports: Dict[str, Set[str]],
+    outside_ports: Dict[Tuple[str, str], str],
+) -> List[Dict[str, Any]]:
+    """The clients hanging off the fabric, as nodes of their own.
+
+    An attachment on a port that faces a node of the inventory is not a client
+    but a fabric link that happens to carry a service - the WAN subinterface of
+    a stitched ip-vrf on a DCGW is the obvious one - so those are left out.
+
+    What remains is grouped per client rather than per subinterface, and several
+    vlans of one cable are one client. Which ports belong to the same client is
+    answered by whichever of these the fabric can tell us, in that order:
+
+    * the name an unmatched LLDP neighbour advertises, because a client that
+      says who it is says the same thing to every leaf it is attached to;
+    * the ESI of the ethernet-segment the port is in, which is how a multi-homed
+      client that runs no LLDP is still drawn as one box rather than one per
+      leaf;
+    * the port itself, when there is nothing else to go on.
+    """
+    grouped: Dict[str, Dict[str, Any]] = {}
+    for node in nodes:
+        for attachment in node.attachments:
+            if attachment.port in fabric_ports.get(node.name, ()):
+                continue
+            advertised = outside_ports.get((node.name, attachment.port))
+            segment = node.segments.get(attachment.port)
+            name = advertised or (segment.esi if segment else "") or f"{node.name}:{attachment.port}"
+            client = grouped.setdefault(
+                name,
+                {
+                    "name": name,
+                    "advertised": advertised or "",
+                    "sites": set(),
+                    "attachments": [],
+                },
+            )
+            client["sites"].add(node.site)
+            client["attachments"].append(
+                {
+                    "node": node.name,
+                    "site": node.site,
+                    "port": attachment.port,
+                    "subinterface": attachment.subinterface,
+                    "service": attachment.service,
+                    "kind": attachment.kind,
+                    "vlan": attachment.vlan,
+                    "ip": attachment.ip,
+                    "state": attachment.oper_state,
+                    "esi": segment.esi if segment else "",
+                    "segment": segment.name if segment else "",
+                }
+            )
+    return [_client_payload(client) for _name, client in sorted(grouped.items())]
+
+
+def _client_payload(client: Dict[str, Any]) -> Dict[str, Any]:
+    attachments = sorted(
+        client["attachments"], key=lambda a: (a["node"], a["port"], a["subinterface"])
+    )
+    sites = {site for site in client["sites"] if site}
+    esis = {a["esi"] for a in attachments if a["esi"]}
+    return {
+        "name": client["name"],
+        # Every client box reads the same. What a client is called is inferred
+        # from an ESI or a port name, which reads like an identity it does not
+        # have; where it is plugged in and what it carries is in the panel.
+        "label": "client",
+        #: The name it advertised over LLDP, on the rare occasion it runs any.
+        "advertised": client["advertised"],
+        "role": "client",
+        "layer": _LAYER_OF["client"],
+        # A client of one site is drawn with it; one spanning two belongs to
+        # neither, and grouping it under either would be a claim we cannot make.
+        "site": sites.pop() if len(sites) == 1 else "",
+        "mac_vrfs": 0,
+        "ip_vrfs": 0,
+        "stitched": 0,
+        "clients": 0,
+        # A port in an ethernet-segment reaches the client through it.
+        "peers": sorted(
+            {_segment_key(a["esi"]) if a["esi"] else a["node"] for a in attachments}
+        ),
+        "ports": len({(a["node"], a["port"]) for a in attachments}),
+        "connected": True,
+        "error": None,
+        "external": False,
+        "attachments": attachments,
+        "services": sorted({a["service"] for a in attachments if a["service"]}),
+        "esi": esis.pop() if len(esis) == 1 else "",
+    }
+
+
+def _client_counts(clients: List[Dict[str, Any]]) -> Dict[str, int]:
+    """How many clients hang off each node, segment in between or not."""
+    counts: Dict[str, int] = {}
+    for client in clients:
+        for name in {a["node"] for a in client["attachments"]}:
+            counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+# --------------------------------------------------------------------------- #
+# ethernet-segments
+# --------------------------------------------------------------------------- #
+
+
+def _segment_key(esi: str) -> str:
+    """The node name of the ethernet-segment with this ESI."""
+    return f"{_SEGMENT_PREFIX}{esi}"
+
+
+def _segment_nodes(clients: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The ethernet-segments the clients are attached over, as nodes of their own.
+
+    Keyed on the ESI rather than on the name, because the ESI is the only thing
+    the leaves of one segment are made to agree on: each configures a name of
+    its own, and two leaves that disagree on it are still one segment.
+    """
+    grouped: Dict[str, Dict[str, Any]] = {}
+    for client in clients:
+        for attachment in client["attachments"]:
+            if not attachment["esi"]:
+                continue
+            segment = grouped.setdefault(
+                attachment["esi"],
+                {
+                    "esi": attachment["esi"],
+                    "names": set(),
+                    "sites": set(),
+                    "clients": set(),
+                    "attachments": [],
+                },
+            )
+            segment["names"].add(attachment["segment"])
+            segment["sites"].add(attachment["site"])
+            segment["clients"].add(client["name"])
+            segment["attachments"].append(attachment)
+    return [_segment_payload(segment) for _esi, segment in sorted(grouped.items())]
+
+
+def _segment_payload(segment: Dict[str, Any]) -> Dict[str, Any]:
+    attachments = sorted(
+        segment["attachments"], key=lambda a: (a["node"], a["port"], a["subinterface"])
+    )
+    names = {name for name in segment["names"] if name}
+    sites = {site for site in segment["sites"] if site}
+    clients = sorted(segment["clients"])
+    return {
+        "name": _segment_key(segment["esi"]),
+        "label": _segment_label(segment["esi"]),
+        #: The name each leaf configured it under, which they may disagree on.
+        "names": sorted(names),
+        "role": "segment",
+        "layer": _LAYER_OF["segment"],
+        "site": sites.pop() if len(sites) == 1 else "",
+        "mac_vrfs": 0,
+        "ip_vrfs": 0,
+        "stitched": 0,
+        "clients": len(clients),
+        "peers": sorted({a["node"] for a in attachments} | set(clients)),
+        "ports": len({(a["node"], a["port"]) for a in attachments}),
+        "connected": True,
+        "error": None,
+        "external": False,
+        "attachments": attachments,
+        "services": sorted({a["service"] for a in attachments if a["service"]}),
+        "esi": segment["esi"],
+    }
+
+
+def _segment_label(esi: str) -> str:
+    """What an ethernet-segment box reads: ``ES`` and the tail of its ESI.
+
+    The tail rather than the name, because the name is configured per leaf and
+    nothing makes the two leaves of one segment agree on it, while the ESI is
+    the one thing they are made to agree on. The last two bytes are what tells
+    the segments of a fabric apart; the rest of an ESI is shared boilerplate.
+    """
+    return f"ES {':'.join(esi.split(':')[-2:])}"
+
+
+# --------------------------------------------------------------------------- #
+# links
+# --------------------------------------------------------------------------- #
+
+
+def _record_link(
+    links: Dict[Tuple[str, str], Dict[str, Any]],
+    node: str,
+    target: str,
+    adj: Adjacency,
+) -> None:
+    """Add one adjacency to the link it belongs to.
+
+    Both ends of a cable report it, so links and the ports of a link are keyed
+    on the pair rather than appended, and a fabric of n cables stays n links
+    however many nodes are streaming.
+    """
+    key = (node, target) if node <= target else (target, node)
+    link = links.setdefault(key, {"a": key[0], "b": key[1], "ports": {}, "states": set()})
+    if node == key[0]:
+        pair = (adj.local_port, adj.peer_port)
+    else:
+        pair = (adj.peer_port, adj.local_port)
+    link["ports"].setdefault(pair, {"a_port": pair[0], "b_port": pair[1]})
+    if adj.oper_state:
+        link["states"].add(adj.oper_state)
+
+
+def _record_access_link(
+    links: Dict[Tuple[str, str], Dict[str, Any]],
+    client: str,
+    attachment: Dict[str, Any],
+) -> None:
+    """Add the cable from a node to a client hanging off one of its ports.
+
+    A client that advertises itself over LLDP already has this cable, reported
+    from the fabric side with both port names on it, so the port is only added
+    when the service is all we have to go on.
+    """
+    node = attachment["node"]
+    key = (node, client) if node <= client else (client, node)
+    link = links.setdefault(key, {"a": key[0], "b": key[1], "ports": {}, "states": set()})
+    link["access"] = True
+    side = 0 if key[0] == node else 1
+    if not any(ports[side] == attachment["port"] for ports in link["ports"]):
+        pair = (attachment["port"], "") if side == 0 else ("", attachment["port"])
+        link["ports"][pair] = {"a_port": pair[0], "b_port": pair[1]}
+    if attachment["state"]:
+        link["states"].add(attachment["state"])
+
+
+def _record_bundle_link(
+    links: Dict[Tuple[str, str], Dict[str, Any]],
+    segment: str,
+    client: str,
+    states: Iterable[str],
+) -> None:
+    """The cable from an ethernet-segment down to the client on it.
+
+    It stands for the bundle as a whole rather than for any one port of it, so
+    it carries no port names: those are on the links from the leaves above.
+    """
+    key = (segment, client) if segment <= client else (client, segment)
+    link = links.setdefault(key, {"a": key[0], "b": key[1], "ports": {}, "states": set()})
+    link["access"] = True
+    link["states"].update(state for state in states if state)
+
+
+def _link_payload(link: Dict[str, Any], layer_of: Dict[str, int]) -> Dict[str, Any]:
+    states = link["states"]
+    if any(state in _DOWN_STATES for state in states):
+        state = "down"
+    elif states and all(state in _UP_STATES for state in states):
+        state = "up"
+    else:
+        state = "unknown"
+    ports = [link["ports"][pair] for pair in sorted(link["ports"])]
+    return {
+        "a": link["a"],
+        "b": link["b"],
+        "count": len(ports),
+        "ports": ports,
+        "state": state,
+        # Set for the links inside one tier: a DCGW mesh, a pair of spines.
+        "intra_layer": layer_of.get(link["a"]) == layer_of.get(link["b"]),
+        # Set for a cable to a client rather than to another node of the fabric.
+        "access": bool(link.get("access")),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# name resolution
+# --------------------------------------------------------------------------- #
+
+
+def _alias_index(nodes: List[NodeFacts]) -> Dict[str, str]:
+    """Map every name a node may be known by onto its inventory name.
+
+    LLDP identifies a neighbour by the system-name it advertises, which is
+    rarely the name the inventory uses: containerlab prefixes the inventory with
+    the lab name while the node keeps its short hostname, and a real fabric
+    hands out FQDNs. An alias two nodes could both answer to is dropped rather
+    than guessed at.
+    """
+    direct: Dict[str, Set[str]] = {}
+    tails: Dict[str, Set[str]] = {}
+    for node in nodes:
+        for alias in (node.name, node.hostname, node.system_name):
+            if not alias:
+                continue
+            text = alias.strip().lower()
+            short = text.split(".")[0]
+            direct.setdefault(text, set()).add(node.name)
+            direct.setdefault(short, set()).add(node.name)
+            tails.setdefault(_tail(short), set()).add(node.name)
+    index = {alias: next(iter(owners)) for alias, owners in direct.items() if len(owners) == 1}
+    for alias, owners in tails.items():
+        if alias not in index and len(owners) == 1:
+            index[alias] = next(iter(owners))
+    return index
+
+
+def _resolve(advertised: str, index: Dict[str, str]) -> Optional[str]:
+    """The inventory name of an advertised system-name, if we have that node."""
+    text = advertised.strip().lower()
+    short = text.split(".")[0]
+    return index.get(text) or index.get(short) or index.get(_tail(short))
+
+
+def _tail(name: str) -> str:
+    """The last dash-separated segment: ``clab-dc1-leaf1`` is ``leaf1``."""
+    return name.rsplit("-", 1)[-1] or name
+
+
+# --------------------------------------------------------------------------- #
+# state parsing
+# --------------------------------------------------------------------------- #
+
+
+def _adjacencies(system: Dict[str, Any], itf_states: Dict[str, str]) -> List[Adjacency]:
+    result = []
+    for itf in _as_list(_branch(system, "lldp").get("interface")):
+        local = str(itf.get("name", ""))
+        if _out_of_band(local):
+            continue
+        for neighbor in _as_list(itf.get("neighbor")):
+            peer = str(neighbor.get("system-name") or "").strip()
+            peer_port = str(neighbor.get("port-id") or "")
+            if not peer or _out_of_band(peer_port):
+                continue
+            result.append(
+                Adjacency(
+                    local_port=local,
+                    peer=peer,
+                    peer_port=peer_port,
+                    oper_state=itf_states.get(local, ""),
+                )
+            )
+    return result
+
+
+def _out_of_band(port: str) -> bool:
+    return port.lower().startswith(_OUT_OF_BAND)
+
+
+def _segments(system: Dict[str, Any]) -> Dict[str, Segment]:
+    """The ethernet-segments of a node, by the port each one is on."""
+    evpn = _branch(system, "network-instance", "protocols", "evpn", "ethernet-segments")
+    result: Dict[str, Segment] = {}
+    for instance in _as_list(evpn.get("bgp-instance")):
+        for segment in _as_list(instance.get("ethernet-segment")):
+            esi = str(segment.get("esi") or "")
+            if not esi:
+                continue
+            for itf in _as_list(segment.get("interface")):
+                port = str(itf.get("ethernet-interface") or "")
+                if port:
+                    result[port] = Segment(name=str(segment.get("name") or ""), esi=esi)
+    return result
+
+
+def _attachments(
+    instance: Dict[str, Any], kind: str, details: Dict[str, Dict[str, Any]]
+) -> List[Attachment]:
+    """The subinterfaces a service binds, minus the ones no client can be on."""
+    service = str(instance.get("name", ""))
+    result = []
+    for member in _as_list(instance.get("interface")):
+        name = str(member.get("name", ""))
+        port = name.rsplit(".", 1)[0]
+        if not port or port.lower().startswith(_VIRTUAL_PORTS):
+            continue
+        detail = details.get(name, {})
+        result.append(
+            Attachment(
+                subinterface=name,
+                port=port,
+                service=service,
+                kind=kind,
+                vlan=_vlan(detail),
+                ip=_first_prefix(detail),
+                # The service's own view of the subinterface first: a member of
+                # a disabled mac-vrf reads up under /interface and down here.
+                oper_state=_norm(member.get("oper-state")) or _norm(detail.get("oper-state")),
+            )
+        )
+    return result
+
+
+def _subinterface_details(snapshot: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Map ``<port>.<index>`` to what ``/interface`` knows about it.
+
+    The network-instance names the subinterfaces bound to it and nothing more,
+    so the vlan and the address a client attaches on come from the other tree.
+    """
+    details: Dict[str, Dict[str, Any]] = {}
+    for itf in _as_list(snapshot.get("interface")):
+        if not itf.get("name"):
+            continue
+        for subinterface in _as_list(itf.get("subinterface")):
+            index = subinterface.get("index", subinterface.get("name"))
+            if index is None:
+                continue
+            details[f"{itf['name']}.{index}"] = subinterface
+    return details
+
+
+def _vlan(detail: Dict[str, Any]) -> str:
+    """The vlan a subinterface is tagged with, as it would be written down."""
+    encap = _branch(detail, "vlan", "encap")
+    tagged = encap.get("single-tagged")
+    if isinstance(tagged, dict) and tagged.get("vlan-id") not in (None, ""):
+        return str(tagged["vlan-id"])
+    if "untagged" in encap:
+        return "untagged"
+    return ""
+
+
+def _first_prefix(detail: Dict[str, Any]) -> str:
+    """The first address of a routed subinterface, v4 before v6."""
+    for family in ("ipv4", "ipv6"):
+        for address in _as_list(_branch(detail, family).get("address")):
+            prefix = address.get("ip-prefix")
+            if prefix:
+                return str(prefix)
+    return ""
+
+
+def _interface_states(snapshot: Dict[str, Any]) -> Dict[str, str]:
+    states = {}
+    for itf in _as_list(snapshot.get("interface")):
+        if not itf.get("name"):
+            continue
+        state = _norm(itf.get("oper-state"))
+        if state:
+            states[str(itf["name"])] = state
+    return states
+
+
+def _is_stitched(instance: Dict[str, Any]) -> bool:
+    """Whether a service is stitched: two enabled bgp-vpn instances with RTs.
+
+    The same rule the service reports use to mark a Gateway, so the topology and
+    the Bridge Domains and Routers tables cannot disagree on what a DCGW is.
+    """
+    enabled = 0
+    for bgp_instance in _as_list(_branch(instance, "protocols", "bgp-vpn").get("bgp-instance")):
+        if _norm(bgp_instance.get("admin-state")) in _DOWN_STATES:
+            continue
+        if _has_route_target(bgp_instance):
+            enabled += 1
+    return enabled >= 2
+
+
+def _has_route_target(bgp_instance: Dict[str, Any]) -> bool:
+    config = bgp_instance.get("route-target")
+    if not isinstance(config, dict):
+        return False
+    for key in ("import-rt", "export-rt"):
+        raw = config.get(key)
+        if isinstance(raw, (str, dict)):
+            raw = [raw]
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            target = item.get("target") if isinstance(item, dict) else item
+            if target:
+                return True
+    return False
+
+
+def _as_list(value: Any) -> List[Dict[str, Any]]:
+    """A yang list as a list of its entries.
+
+    gNMI returns a list of one as the entry itself, and a container that is not
+    there at all as nothing, so every list has to be read through this.
+    """
+    if isinstance(value, dict):
+        return [value]
+    if not isinstance(value, list):
+        return []
+    return [entry for entry in value if isinstance(entry, dict)]
+
+
+def _branch(node: Any, *names: str) -> Dict[str, Any]:
+    """Descend through nested containers, yielding ``{}`` at the first miss."""
+    for name in names:
+        if not isinstance(node, dict):
+            return {}
+        node = node.get(name, {})
+    return node if isinstance(node, dict) else {}
+
+
+def _norm(value: Any) -> str:
+    """Normalize a YANG enum leaf to its bare, lower-case value."""
+    if not value:
+        return ""
+    return str(value).lower().split(":")[-1]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -158,6 +158,39 @@ LLDP_RESPONSE: List[Dict[str, Any]] = [
     }
 ]
 
+HOSTNAME_PATH = "/system/name/host-name"
+
+
+def hostname_response(name: str) -> List[Dict[str, Any]]:
+    """What a node answers when asked for the name it advertises over LLDP."""
+    return [{"system/name": {"host-name": name}}]
+
+
+ES_PATH = "/system/network-instance/protocols/evpn/ethernet-segments"
+
+
+def es_response(name: str, esi: str, interface: str) -> List[Dict[str, Any]]:
+    """One ethernet-segment, as the two nodes sharing it both report it."""
+    return [
+        {
+            "system/network-instance/protocols/evpn/ethernet-segments": {
+                "bgp-instance": [
+                    {
+                        "id": 1,
+                        "ethernet-segment": [
+                            {
+                                "name": name,
+                                "esi": esi,
+                                "interface": [{"ethernet-interface": interface}],
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    ]
+
+
 IFSTATS_PATH = "/interface[name=*]/statistics"
 IFSTATS_RESPONSE: List[Dict[str, Any]] = [
     {

--- a/tests/system/capture.py
+++ b/tests/system/capture.py
@@ -39,9 +39,9 @@ DEFAULT_USERNAME = "admin"
 DEFAULT_PASSWORD = "NokiaSrl1!"
 DEFAULT_PORT = 57400
 
-#: ``overview`` is computed by the server from streamed state rather than by a
-#: getter, so there is no gNMI exchange of its own to record.
-SKIP = {"overview"}
+#: ``overview`` and ``topology`` are computed by the server from streamed state
+#: rather than by a getter, so there is no gNMI exchange of their own to record.
+SKIP = {"overview", "topology"}
 
 
 class RecordingDevice(SrLinux):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -52,6 +52,33 @@ def test_every_getter_is_callable_with_only_a_device():
             ), f"{report.name} getter requires '{param.name}'"
 
 
+#: Single leaves SR Linux defines as config rather than state.
+CONFIG_LEAVES = frozenset(
+    {
+        "/interface[name=*]/admin-state",
+        "/interface[name=*]/description",
+        "/network-instance[name=*]/type",
+        "/system/name/host-name",
+    }
+)
+
+
+def test_config_leaves_are_not_subscribed_as_state():
+    """A 'state' Get on a config leaf answers nothing, and answers it silently.
+
+    The path is then never bootstrapped, so it stays pending forever and the
+    report reading it renders as though the node had no such data - which is how
+    the topology once put every node of a fabric on one tier.
+    """
+    for report in REPORTS:
+        for spec in report.subscribe:
+            if spec.path in CONFIG_LEAVES:
+                assert spec.datatype != "state", (
+                    f"{report.name} subscribes to the config leaf {spec.path} "
+                    "with datatype 'state', which returns nothing"
+                )
+
+
 def test_non_tabular_reports_are_not_streamed():
     """The browser only shows tables, so a report without columns cannot stream."""
     for report in REPORTS:

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -13,10 +13,19 @@ from starlette.testclient import TestClient
 
 from nornir_srl.reports import SERVER, get_report, reports_for
 from nornir_srl.rows import flatten, get_fields, is_scalar
-from nornir_srl.server.app import create_app, parse_kv, table_digest, table_events
+from nornir_srl.server.app import (
+    ASSET_TOKEN,
+    asset_version,
+    create_app,
+    parse_kv,
+    table_digest,
+    table_events,
+)
 from nornir_srl.server.store import FabricStore
 
 from .fakes import (
+    ES_PATH,
+    HOSTNAME_PATH,
     IFADMIN_PATH,
     IFADMIN_RESPONSE,
     IFSTATE_PATH,
@@ -27,6 +36,8 @@ from .fakes import (
     LLDP_RESPONSE,
     SYS_INFO_RESPONSES,
     FakeDevice,
+    es_response,
+    hostname_response,
     wait_for,
 )
 
@@ -41,10 +52,15 @@ HOSTS = {
     "spine1": {"hostname": "spine1", "platform": "srlinux", "data": {"role": "spine"}},
 }
 
+#: The segment both fake nodes report on lag1, as a multi-homing pair does.
+ES_ESI = "00:00:00:00:01:01:01:01:01:01"
 
-def _responses():
+
+def _responses(name="leaf1"):
     return {
         LLDP_PATH: LLDP_RESPONSE,
+        HOSTNAME_PATH: hostname_response(name),
+        ES_PATH: es_response("mh-1", ES_ESI, "lag1"),
         IFSTATS_PATH: IFSTATS_RESPONSE,
         IFSTATE_PATH: IFSTATE_RESPONSE,
         IFADMIN_PATH: IFADMIN_RESPONSE,
@@ -89,7 +105,7 @@ def fabric(monkeypatch):
             runner={"plugin": "serial"},
             logging={"enabled": False},
         )
-        devices = {name: FakeDevice(_responses()) for name in HOSTS}
+        devices = {name: FakeDevice(_responses(name)) for name in HOSTS}
         monkeypatch.setattr(
             "nornir.core.inventory.Host.get_connection",
             lambda self, name, config: devices[self.name],
@@ -583,6 +599,25 @@ def test_static_assets_are_served(client):
     assert test_client.get("/static/style.css").status_code == 200
 
 
+def test_the_page_is_never_cached_and_its_assets_are_fingerprinted(client):
+    test_client, _devices = client
+    response = test_client.get("/")
+    assert response.headers["cache-control"] == "no-cache"
+    assert ASSET_TOKEN not in response.text
+    assert f"/static/app.js?v={asset_version()}" in response.text
+    assert f"/static/style.css?v={asset_version()}" in response.text
+
+
+def test_the_asset_version_follows_the_assets(tmp_path, monkeypatch):
+    monkeypatch.setattr("nornir_srl.server.app.STATIC_DIR", tmp_path)
+    (tmp_path / "app.js").write_text("//")
+    (tmp_path / "style.css").write_text("/**/")
+    before = asset_version()
+
+    os.utime(tmp_path / "app.js", ns=(0, 2_000_000_000_000_000_000))
+    assert asset_version() != before
+
+
 def test_reports_endpoint_lists_every_report(client):
     test_client, _devices = client
     payload = test_client.get("/api/reports").json()
@@ -717,6 +752,139 @@ def test_store_overview_method(store):
     assert isinstance(data["telemetry"]["subscriptions"], int)
     assert isinstance(data["bridge_domains"]["total"], int)
     assert isinstance(data["routers"]["total"], int)
+
+
+def _push_services(stream, *instances):
+    """Give a node the network-instance state the topology classifies it on."""
+    stream._tree["network-instance"] = list(instances)
+
+
+def _mac_vrf(*route_targets):
+    return {
+        "name": "mac-vrf-100",
+        "type": "mac-vrf",
+        "protocols": {
+            "bgp-vpn": {
+                "bgp-instance": [
+                    {"id": index, "route-target": {"export-rt": rt, "import-rt": rt}}
+                    for index, rt in enumerate(route_targets, start=1)
+                ]
+            }
+        },
+    }
+
+
+def test_topology_endpoint(client):
+    test_client, _devices = client
+    resp = test_client.get("/api/topology")
+    assert resp.status_code == 200
+    graph = resp.json()
+    assert {n["name"] for n in graph["nodes"]} >= set(HOSTS)
+    assert any({link["a"], link["b"]} == {"leaf1", "spine1"} for link in graph["links"])
+    # Both nodes advertise a neighbour the inventory does not have.
+    assert graph["unresolved"] == [{"peer": "spine2", "seen_by": ["leaf1", "spine1"]}]
+
+
+def test_topology_endpoint_honours_the_inventory_filter(client):
+    test_client, _devices = client
+    graph = test_client.get("/api/topology?inv_filter=role%3Dspine").json()
+    assert {n["name"] for n in graph["nodes"] if not n["external"]} == {"spine1"}
+
+
+def test_topology_subscribes_to_lldp_and_the_services(store):
+    fabric_store, devices = store
+    fabric_store.topology()
+    assert wait_for(lambda: devices["leaf1"].subscribe_requests)
+    streamed = [s["path"] for s in devices["leaf1"].subscribe_requests[-1]["subscription"]]
+    assert LLDP_PATH in streamed
+    assert HOSTNAME_PATH in streamed
+    # The service paths are registered as well; this fake node answers nothing
+    # for them, which leaves them pending rather than streaming.
+    registered = {p["path"] for p in fabric_store._streams["leaf1"].status()["paths"]}
+    assert "/network-instance[name=*]/type" in registered
+    assert "/network-instance[name=*]/protocols/bgp-vpn" in registered
+    assert "/network-instance[name=*]/interface" in registered
+    assert "/system/network-instance/protocols/evpn/ethernet-segments" in registered
+
+
+def test_topology_infers_the_tier_from_the_services_of_a_node(store):
+    fabric_store, _devices = store
+    fabric_store.topology()
+    _push_services(
+        fabric_store._streams["leaf1"],
+        {"name": "default", "type": "default"},
+        _mac_vrf("target:100:100"),
+    )
+    _push_services(
+        fabric_store._streams["spine1"], {"name": "default", "type": "default"}
+    )
+    graph = fabric_store.topology()
+    roles = {n["name"]: n["role"] for n in graph["nodes"]}
+    assert roles["leaf1"] == "leaf"
+    # spine1 runs no services and leaf1 reports it as a neighbour.
+    assert roles["spine1"] == "spine"
+    assert [layer["index"] for layer in graph["layers"]] == [4, 3, 2]
+
+
+def test_topology_marks_a_stitched_service_as_a_gateway(store):
+    fabric_store, _devices = store
+    fabric_store.topology()
+    _push_services(
+        fabric_store._streams["leaf1"],
+        {"name": "default", "type": "default"},
+        _mac_vrf("target:100:100", "target:64500:100"),
+    )
+    graph = fabric_store.topology()
+    leaf1 = next(n for n in graph["nodes"] if n["name"] == "leaf1")
+    assert leaf1["role"] == "dcgw"
+    assert leaf1["stitched"] == 1
+
+
+def test_topology_hangs_a_client_off_the_port_a_service_is_bound_to(store):
+    fabric_store, _devices = store
+    fabric_store.topology()
+    mac_vrf = _mac_vrf("target:100:100")
+    mac_vrf["interface"] = [{"name": "irb0.100"}, {"name": "ethernet-1/10.100"}]
+    _push_services(
+        fabric_store._streams["leaf1"], {"name": "default", "type": "default"}, mac_vrf
+    )
+    graph = fabric_store.topology()
+    client = next(n for n in graph["nodes"] if n["role"] == "client")
+    assert (client["name"], client["layer"]) == ("leaf1:ethernet-1/10", 0)
+    assert client["peers"] == ["leaf1"]
+    assert client["services"] == ["mac-vrf-100"]
+    assert graph["layers"][-1]["label"] == "Clients"
+    leaf1 = next(n for n in graph["nodes"] if n["name"] == "leaf1")
+    assert leaf1["clients"] == 1
+
+
+def test_topology_merges_a_multi_homed_client_by_its_ethernet_segment(store):
+    """The ESI has to survive the trip from the Get through the streamed tree."""
+    fabric_store, _devices = store
+    fabric_store.topology()
+    for name in HOSTS:
+        mac_vrf = _mac_vrf("target:100:100")
+        mac_vrf["interface"] = [{"name": "lag1.100"}]
+        _push_services(
+            fabric_store._streams[name], {"name": "default", "type": "default"}, mac_vrf
+        )
+    graph = fabric_store.topology()
+    clients = [n for n in graph["nodes"] if n["role"] == "client"]
+    assert len(clients) == 1
+    assert clients[0]["name"] == ES_ESI
+    # It hangs off the one bundle, which is what spans the two nodes.
+    segment = next(n for n in graph["nodes"] if n["role"] == "segment")
+    assert (segment["label"], segment["esi"]) == ("ES 01:01", ES_ESI)
+    assert segment["names"] == ["mh-1"]
+    assert segment["peers"] == [ES_ESI, "leaf1", "spine1"]
+    assert clients[0]["peers"] == [segment["name"]]
+
+
+def test_topology_keeps_a_node_that_has_streamed_nothing(store):
+    fabric_store, _devices = store
+    graph = fabric_store.topology()
+    assert {n["role"] for n in graph["nodes"] if n["name"] in HOSTS} == {"unknown"}
+    assert all(n["connected"] for n in graph["nodes"] if n["name"] in HOSTS)
 
 
 @pytest.mark.anyio

--- a/tests/test_server_topology.py
+++ b/tests/test_server_topology.py
@@ -1,0 +1,1083 @@
+"""Tests for the topology inferred from LLDP and service placement.
+
+The fabric built here is the shape the inference has to get right: two leaves per
+site under a pair of spines, DCGWs stitching the sites, and a WAN router that has
+no services either but is not a spine.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from nornir_srl.server.topology import build_topology, node_facts
+
+
+def _rt_instance(instance_id: int, route_target: str) -> Dict[str, Any]:
+    return {
+        "id": instance_id,
+        "route-target": {"import-rt": route_target, "export-rt": route_target},
+    }
+
+
+def _ni(
+    name: str,
+    ni_type: str,
+    *instances: Dict[str, Any],
+    members: Tuple[str, ...] = (),
+) -> Dict[str, Any]:
+    instance: Dict[str, Any] = {"name": name, "type": ni_type}
+    if instances:
+        instance["protocols"] = {"bgp-vpn": {"bgp-instance": list(instances)}}
+    if members:
+        instance["interface"] = [{"name": member} for member in members]
+    return instance
+
+
+def _subinterfaces(port: str, *indices: Dict[str, Any]) -> Dict[str, Any]:
+    """An ``/interface`` entry carrying the detail of its subinterfaces."""
+    return {"name": port, "subinterface": list(indices)}
+
+
+def _segments(*segments: Tuple[str, str, str]) -> Dict[str, Any]:
+    """An EVPN tree from ``(segment name, esi, interface)`` triples."""
+    return {
+        "network-instance": {
+            "protocols": {
+                "evpn": {
+                    "ethernet-segments": {
+                        "bgp-instance": [
+                            {
+                                "id": 1,
+                                "ethernet-segment": [
+                                    {
+                                        "name": name,
+                                        "esi": esi,
+                                        "interface": [{"ethernet-interface": itf}],
+                                    }
+                                    for name, esi, itf in segments
+                                ],
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+
+def _lldp(*cables: Tuple[str, str, str]) -> Dict[str, Any]:
+    """An LLDP tree from ``(local port, neighbour, neighbour port)`` triples."""
+    return {
+        "lldp": {
+            "interface": [
+                {
+                    "name": local,
+                    "neighbor": [{"id": "1", "system-name": peer, "port-id": peer_port}],
+                }
+                for local, peer, peer_port in cables
+            ]
+        }
+    }
+
+
+def _facts(
+    name: str,
+    *,
+    host_name: Optional[str] = None,
+    site: str = "",
+    cables: Tuple[Tuple[str, str, str], ...] = (),
+    instances: Tuple[Dict[str, Any], ...] = (),
+    interfaces: Tuple[Dict[str, Any], ...] = (),
+    segments: Tuple[Tuple[str, str, str], ...] = (),
+    connected: bool = True,
+):
+    system = _lldp(*cables)
+    if host_name is not None:
+        system["name"] = {"host-name": host_name}
+    if segments:
+        system.update(_segments(*segments))
+    snapshot: Dict[str, Any] = {"system": system}
+    if instances:
+        snapshot["network-instance"] = list(instances)
+    if interfaces:
+        snapshot["interface"] = list(interfaces)
+    return node_facts(
+        f"clab-dc-{name}",
+        hostname=f"clab-dc-{name}",
+        labels={"site": site} if site else {},
+        snapshot=snapshot,
+        connected=connected,
+    )
+
+
+#: One mac-vrf and one ip-vrf, each with a single bgp-vpn instance: a leaf.
+LEAF_SERVICES = (
+    _ni("default", "default"),
+    _ni("mac-vrf-100", "mac-vrf", _rt_instance(1, "100:100")),
+    _ni("ip-vrf-1", "ip-vrf", _rt_instance(1, "100:1")),
+)
+
+#: The same services with a second, WAN-side instance: a DCGW.
+GATEWAY_SERVICES = (
+    _ni("default", "default"),
+    _ni(
+        "mac-vrf-100",
+        "mac-vrf",
+        _rt_instance(1, "100:100"),
+        _rt_instance(2, "64500:100"),
+    ),
+    _ni("ip-vrf-1", "ip-vrf", _rt_instance(1, "100:1"), _rt_instance(2, "64500:1")),
+)
+
+#: A node that runs the fabric but terminates nothing: spine, or WAN router.
+NO_SERVICES = (_ni("default", "default"), _ni("mgmt", "ip-vrf"))
+
+
+def _fabric() -> List[Any]:
+    return [
+        _facts(
+            "leaf1",
+            host_name="leaf1",
+            site="dc1",
+            cables=(
+                ("ethernet-1/1", "spine1", "ethernet-1/1"),
+                ("ethernet-1/2", "spine2", "ethernet-1/1"),
+            ),
+            instances=LEAF_SERVICES,
+        ),
+        _facts(
+            "leaf2",
+            host_name="leaf2",
+            site="dc1",
+            cables=(
+                ("ethernet-1/1", "spine1", "ethernet-1/2"),
+                ("ethernet-1/2", "spine2", "ethernet-1/2"),
+            ),
+            instances=LEAF_SERVICES,
+        ),
+        _facts(
+            "spine1",
+            host_name="spine1",
+            site="dc1",
+            cables=(
+                ("ethernet-1/1", "leaf1", "ethernet-1/1"),
+                ("ethernet-1/2", "leaf2", "ethernet-1/1"),
+                ("ethernet-1/5", "dcgw1", "ethernet-1/1"),
+            ),
+            instances=NO_SERVICES,
+        ),
+        _facts(
+            "spine2",
+            host_name="spine2",
+            site="dc1",
+            cables=(
+                ("ethernet-1/1", "leaf1", "ethernet-1/2"),
+                ("ethernet-1/2", "leaf2", "ethernet-1/2"),
+                ("ethernet-1/5", "dcgw1", "ethernet-1/2"),
+            ),
+            instances=NO_SERVICES,
+        ),
+        _facts(
+            "dcgw1",
+            host_name="dcgw1",
+            site="dc1",
+            cables=(
+                ("ethernet-1/1", "spine1", "ethernet-1/5"),
+                ("ethernet-1/2", "spine2", "ethernet-1/5"),
+                ("ethernet-1/5", "dcgw2", "ethernet-1/5"),
+                ("ethernet-1/6", "p1", "ethernet-1/1"),
+            ),
+            instances=GATEWAY_SERVICES,
+        ),
+        _facts(
+            "dcgw2",
+            host_name="dcgw2",
+            site="dc2",
+            cables=(
+                ("ethernet-1/5", "dcgw1", "ethernet-1/5"),
+                ("ethernet-1/6", "p1", "ethernet-1/2"),
+            ),
+            instances=GATEWAY_SERVICES,
+        ),
+        _facts(
+            "p1",
+            host_name="p1",
+            site="wan",
+            cables=(
+                ("ethernet-1/1", "dcgw1", "ethernet-1/6"),
+                ("ethernet-1/2", "dcgw2", "ethernet-1/6"),
+                ("ethernet-1/5", "p2", "ethernet-1/5"),
+            ),
+            instances=NO_SERVICES,
+        ),
+    ]
+
+
+def _roles(graph: Dict[str, Any]) -> Dict[str, str]:
+    return {node["label"]: node["role"] for node in graph["nodes"]}
+
+
+# --------------------------------------------------------------------------- #
+# reading the streamed state
+# --------------------------------------------------------------------------- #
+
+
+def test_node_facts_counts_the_services_of_a_leaf():
+    facts = _facts("leaf1", host_name="leaf1", instances=LEAF_SERVICES)
+    assert facts.mac_vrfs == 1
+    assert facts.ip_vrfs == 1
+    assert facts.stitched == 0
+    assert facts.has_state
+
+
+def test_node_facts_marks_two_bgp_vpn_instances_as_stitched():
+    facts = _facts("dcgw1", host_name="dcgw1", instances=GATEWAY_SERVICES)
+    assert facts.stitched == 2
+
+
+def test_node_facts_ignores_the_mgmt_ip_vrf():
+    facts = _facts("spine1", host_name="spine1", instances=NO_SERVICES)
+    assert (facts.mac_vrfs, facts.ip_vrfs) == (0, 0)
+    assert facts.has_state
+
+
+def test_node_facts_without_state_is_not_a_node_without_services():
+    facts = _facts("leaf9")
+    assert not facts.has_state
+    assert facts.adjacencies == []
+
+
+def test_node_facts_leaves_out_the_management_network():
+    """Every node of a lab sees every other one on the management bridge."""
+    facts = _facts(
+        "leaf1",
+        host_name="leaf1",
+        cables=(
+            ("ethernet-1/1", "spine1", "ethernet-1/1"),
+            ("mgmt0", "spine1", "mgmt0"),
+            ("mgmt0", "p1", "mgmt0"),
+        ),
+    )
+    assert [adjacency.local_port for adjacency in facts.adjacencies] == ["ethernet-1/1"]
+
+
+def test_node_facts_leaves_out_a_neighbour_reached_on_its_management_port():
+    """The other end may be a device whose management port is not named mgmt0."""
+    facts = _facts(
+        "leaf1",
+        host_name="leaf1",
+        cables=(("ethernet-1/1", "server1", "mgmt-eth0"),),
+    )
+    assert facts.adjacencies == []
+
+
+def test_the_management_mesh_does_not_flatten_the_roles():
+    """The mesh gives every node the same neighbours, which classifies nothing."""
+    fabric = _fabric()
+    graph = build_topology(fabric)
+    meshed = [
+        _facts(
+            node.name.removeprefix("clab-dc-"),
+            host_name=node.system_name,
+            site=node.site,
+            cables=tuple(
+                (adjacency.local_port, adjacency.peer, adjacency.peer_port)
+                for adjacency in node.adjacencies
+            )
+            + tuple(
+                ("mgmt0", other.system_name, "mgmt0")
+                for other in fabric
+                if other.name != node.name
+            ),
+            instances=tuple(_instances_of(node)),
+        )
+        for node in fabric
+    ]
+    assert _roles(build_topology(meshed)) == _roles(graph)
+
+
+def _instances_of(node):
+    """The service set a node was built with, recovered from its counters."""
+    if node.stitched:
+        return GATEWAY_SERVICES
+    if node.mac_vrfs:
+        return LEAF_SERVICES
+    return NO_SERVICES
+
+
+def test_node_facts_reads_lldp_neighbours_and_the_local_port_state():
+    facts = _facts(
+        "leaf1",
+        host_name="leaf1",
+        cables=(("ethernet-1/1", "spine1", "ethernet-1/49"),),
+        interfaces=({"name": "ethernet-1/1", "oper-state": "up"},),
+    )
+    adjacency = facts.adjacencies[0]
+    assert (adjacency.local_port, adjacency.peer, adjacency.peer_port) == (
+        "ethernet-1/1",
+        "spine1",
+        "ethernet-1/49",
+    )
+    assert adjacency.oper_state == "up"
+
+
+# --------------------------------------------------------------------------- #
+# roles
+# --------------------------------------------------------------------------- #
+
+
+def test_services_make_a_leaf_and_stitched_services_make_a_gateway():
+    roles = _roles(build_topology(_fabric()))
+    assert roles["leaf1"] == "leaf"
+    assert roles["leaf2"] == "leaf"
+    assert roles["dcgw1"] == "dcgw"
+    assert roles["dcgw2"] == "dcgw"
+
+
+def test_a_node_without_services_that_sees_leaves_is_a_spine():
+    roles = _roles(build_topology(_fabric()))
+    assert roles["spine1"] == "spine"
+    assert roles["spine2"] == "spine"
+
+
+def test_a_node_without_services_that_only_sees_gateways_is_core():
+    """A WAN router has no mac-vrfs either, but it is not a spine."""
+    roles = _roles(build_topology(_fabric()))
+    assert roles["p1"] == "core"
+
+
+def test_a_single_leaf_fabric_still_has_a_spine():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("ethernet-1/1", "spine1", "ethernet-1/1"),),
+                instances=LEAF_SERVICES,
+            ),
+            _facts(
+                "spine1",
+                host_name="spine1",
+                cables=(("ethernet-1/1", "leaf1", "ethernet-1/1"),),
+                instances=NO_SERVICES,
+            ),
+        ]
+    )
+    assert _roles(graph) == {"leaf1": "leaf", "spine1": "spine"}
+
+
+def test_a_node_that_streamed_nothing_yet_is_unclassified():
+    graph = build_topology([*_fabric(), _facts("leaf9", connected=False)])
+    node = next(n for n in graph["nodes"] if n["label"].endswith("leaf9"))
+    assert node["role"] == "unknown"
+    assert node["layer"] == 2
+    assert node["connected"] is False
+
+
+def test_roles_are_counted_per_fabric():
+    assert build_topology(_fabric())["roles"] == {
+        "core": 1,
+        "dcgw": 2,
+        "spine": 2,
+        "leaf": 2,
+        "external": 1,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# layers
+# --------------------------------------------------------------------------- #
+
+
+def test_layers_run_from_the_wan_down_to_the_leaves():
+    graph = build_topology(_fabric())
+    assert [layer["index"] for layer in graph["layers"]] == [6, 5, 4, 3, 2]
+    assert [layer["label"] for layer in graph["layers"]] == [
+        "WAN / core",
+        "DC gateways",
+        "Spines",
+        "Leaves",
+        "Edge / unclassified",
+    ]
+    tiers = {layer["index"]: layer["nodes"] for layer in graph["layers"]}
+    assert tiers[3] == ["clab-dc-leaf1", "clab-dc-leaf2"]
+    assert tiers[6] == ["clab-dc-p1"]
+
+
+def test_empty_tiers_are_left_out():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("ethernet-1/1", "spine1", "ethernet-1/1"),),
+                instances=LEAF_SERVICES,
+            ),
+            _facts(
+                "spine1",
+                host_name="spine1",
+                cables=(("ethernet-1/1", "leaf1", "ethernet-1/1"),),
+                instances=NO_SERVICES,
+            ),
+        ]
+    )
+    assert [layer["index"] for layer in graph["layers"]] == [4, 3]
+
+
+def test_sites_come_from_the_inventory_labels():
+    assert build_topology(_fabric())["sites"] == ["dc1", "dc2", "wan"]
+
+
+# --------------------------------------------------------------------------- #
+# links
+# --------------------------------------------------------------------------- #
+
+
+def _link(graph: Dict[str, Any], a: str, b: str) -> Dict[str, Any]:
+    pair = {f"clab-dc-{a}", f"clab-dc-{b}"}
+    return next(link for link in graph["links"] if {link["a"], link["b"]} == pair)
+
+
+def test_a_cable_reported_by_both_ends_is_one_link():
+    graph = build_topology(_fabric())
+    # 4 leaf-spine, 2 spine-dcgw, 1 dcgw mesh, 2 dcgw-p1, 1 p1 to the outside.
+    assert len(graph["links"]) == 10
+    link = _link(graph, "leaf1", "spine1")
+    assert link["count"] == 1
+    assert link["ports"] == [{"a_port": "ethernet-1/1", "b_port": "ethernet-1/1"}]
+
+
+def test_parallel_cables_between_two_nodes_are_one_link():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(
+                    ("ethernet-1/1", "spine1", "ethernet-1/1"),
+                    ("ethernet-1/3", "spine1", "ethernet-1/3"),
+                ),
+                instances=LEAF_SERVICES,
+            ),
+            _facts(
+                "spine1",
+                host_name="spine1",
+                cables=(
+                    ("ethernet-1/1", "leaf1", "ethernet-1/1"),
+                    ("ethernet-1/3", "leaf1", "ethernet-1/3"),
+                ),
+                instances=NO_SERVICES,
+            ),
+        ]
+    )
+    assert len(graph["links"]) == 1
+    assert graph["links"][0]["count"] == 2
+
+
+def test_links_inside_one_tier_are_marked():
+    graph = build_topology(_fabric())
+    assert _link(graph, "dcgw1", "dcgw2")["intra_layer"] is True
+    assert _link(graph, "leaf1", "spine1")["intra_layer"] is False
+
+
+def test_link_state_follows_the_port_state_of_either_end():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(
+                    ("ethernet-1/1", "spine1", "ethernet-1/1"),
+                    ("ethernet-1/2", "spine2", "ethernet-1/1"),
+                ),
+                instances=LEAF_SERVICES,
+                interfaces=(
+                    {"name": "ethernet-1/1", "oper-state": "up"},
+                    {"name": "ethernet-1/2", "oper-state": "down"},
+                ),
+            ),
+            _facts("spine1", host_name="spine1", instances=NO_SERVICES),
+            _facts("spine2", host_name="spine2", instances=NO_SERVICES),
+        ]
+    )
+    assert _link(graph, "leaf1", "spine1")["state"] == "up"
+    assert _link(graph, "leaf1", "spine2")["state"] == "down"
+
+
+def test_a_link_whose_port_state_is_unknown_is_not_called_up():
+    graph = build_topology(_fabric())
+    assert _link(graph, "leaf1", "spine1")["state"] == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# resolving neighbours to inventory nodes
+# --------------------------------------------------------------------------- #
+
+
+def test_a_neighbour_is_matched_through_the_containerlab_prefix():
+    """LLDP advertises 'leaf1'; the inventory calls the same node 'clab-dc-leaf1'."""
+    graph = build_topology(_fabric())
+    leaf1 = next(n for n in graph["nodes"] if n["label"] == "leaf1")
+    assert leaf1["name"] == "clab-dc-leaf1"
+    assert leaf1["peers"] == ["clab-dc-spine1", "clab-dc-spine2"]
+
+
+def test_a_neighbour_is_matched_without_a_host_name_of_its_own():
+    """A node that has not streamed its host-name is still resolvable by name."""
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("ethernet-1/1", "spine1", "ethernet-1/1"),),
+                instances=LEAF_SERVICES,
+            ),
+            _facts("spine1", instances=NO_SERVICES),
+        ]
+    )
+    assert len(graph["links"]) == 1
+    assert graph["unresolved"] == []
+
+
+def test_a_neighbour_with_a_domain_suffix_is_matched():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("ethernet-1/1", "spine1.dc1.example.net", "ethernet-1/1"),),
+                instances=LEAF_SERVICES,
+            ),
+            _facts("spine1", host_name="spine1", instances=NO_SERVICES),
+        ]
+    )
+    assert graph["unresolved"] == []
+    assert _link(graph, "leaf1", "spine1")["count"] == 1
+
+
+def test_a_neighbour_outside_the_inventory_is_kept_as_an_external_node():
+    graph = build_topology(_fabric())
+    assert graph["unresolved"] == [{"peer": "p2", "seen_by": ["clab-dc-p1"]}]
+    external = next(n for n in graph["nodes"] if n["external"])
+    assert (external["name"], external["role"], external["layer"]) == ("p2", "external", 2)
+    assert any({link["a"], link["b"]} == {"clab-dc-p1", "p2"} for link in graph["links"])
+
+
+def test_a_neighbour_advertising_our_own_name_is_not_a_link():
+    """Two nodes of a lab sharing a host-name would otherwise draw a self-loop."""
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("ethernet-1/1", "leaf1", "ethernet-1/1"),),
+                instances=LEAF_SERVICES,
+            )
+        ]
+    )
+    assert graph["links"] == []
+
+
+def test_an_ambiguous_name_is_not_resolved_to_either_node():
+    """Two nodes answering to one name is a lab mistake, not a link to guess at."""
+    graph = build_topology(
+        [
+            _facts("leaf1", host_name="dup", instances=LEAF_SERVICES),
+            _facts("leaf2", host_name="dup", instances=LEAF_SERVICES),
+            _facts(
+                "spine1",
+                host_name="spine1",
+                cables=(("ethernet-1/1", "dup", "ethernet-1/1"),),
+                instances=NO_SERVICES,
+            ),
+        ]
+    )
+    assert [entry["peer"] for entry in graph["unresolved"]] == ["dup"]
+
+
+# --------------------------------------------------------------------------- #
+# clients
+# --------------------------------------------------------------------------- #
+
+#: A leaf with a customer on ethernet-1/10: the mac-vrf holds the access
+#: subinterface next to its IRB, and the ip-vrf holds only the IRB.
+CLIENT_SERVICES = (
+    _ni("default", "default"),
+    _ni(
+        "mac-vrf-100",
+        "mac-vrf",
+        _rt_instance(1, "100:100"),
+        members=("irb0.100", "ethernet-1/10.100"),
+    ),
+    _ni("ip-vrf-1", "ip-vrf", _rt_instance(1, "100:1"), members=("irb0.100",)),
+)
+
+
+def _clients(graph: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [node for node in graph["nodes"] if node["role"] == "client"]
+
+
+def _leaf_with_a_client(name: str = "leaf1", **kwargs: Any):
+    return _facts(
+        name,
+        host_name=name,
+        site="dc1",
+        cables=(("ethernet-1/1", "spine1", "ethernet-1/1"),),
+        instances=CLIENT_SERVICES,
+        **kwargs,
+    )
+
+
+def test_a_bridged_subinterface_of_a_mac_vrf_is_a_client():
+    graph = build_topology([_leaf_with_a_client()])
+    client = _clients(graph)[0]
+    assert client["name"] == "clab-dc-leaf1:ethernet-1/10"
+    assert client["peers"] == ["clab-dc-leaf1"]
+    assert client["services"] == ["mac-vrf-100"]
+    attachment = client["attachments"][0]
+    assert attachment["kind"] == "bridged"
+    assert attachment["subinterface"] == "ethernet-1/10.100"
+    assert attachment["service"] == "mac-vrf-100"
+
+
+def test_a_routed_port_of_an_ip_vrf_is_a_client():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                instances=(
+                    _ni("default", "default"),
+                    _ni("ip-vrf-1", "ip-vrf", members=("irb0.100", "ethernet-1/20.0")),
+                ),
+            )
+        ]
+    )
+    attachment = _clients(graph)[0]["attachments"][0]
+    assert (attachment["kind"], attachment["subinterface"]) == ("routed", "ethernet-1/20.0")
+
+
+def test_the_interfaces_a_service_binds_to_itself_are_not_clients():
+    """An IRB, a loopback and system0 are the node's own, not a customer's."""
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                instances=(
+                    _ni(
+                        "ip-vrf-1",
+                        "ip-vrf",
+                        members=("irb0.100", "lo0.1", "system0.0", "mgmt0.0"),
+                    ),
+                ),
+            )
+        ]
+    )
+    assert _clients(graph) == []
+
+
+def test_a_service_on_a_fabric_port_is_not_a_client():
+    """The WAN subinterface of a stitched ip-vrf lands on the DCGW's neighbour."""
+    graph = build_topology(
+        [
+            _facts(
+                "dcgw1",
+                host_name="dcgw1",
+                cables=(("ethernet-1/6", "p1", "ethernet-1/1"),),
+                instances=(
+                    _ni("default", "default"),
+                    _ni(
+                        "ip-vrf-1",
+                        "ip-vrf",
+                        _rt_instance(1, "100:1"),
+                        _rt_instance(2, "64500:1"),
+                        members=("irb0.100", "ethernet-1/6.0"),
+                    ),
+                ),
+            ),
+            _facts("p1", host_name="p1", instances=NO_SERVICES),
+        ]
+    )
+    assert _clients(graph) == []
+
+
+def test_two_vlans_of_one_cable_are_one_client():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                instances=(
+                    _ni("mac-vrf-100", "mac-vrf", members=("ethernet-1/10.100",)),
+                    _ni("mac-vrf-200", "mac-vrf", members=("ethernet-1/10.200",)),
+                ),
+            )
+        ]
+    )
+    clients = _clients(graph)
+    assert len(clients) == 1
+    assert clients[0]["services"] == ["mac-vrf-100", "mac-vrf-200"]
+    assert clients[0]["ports"] == 1
+
+
+def test_a_client_that_advertises_itself_is_named_after_it_on_every_leaf():
+    """A dual-homed server is one box, which only LLDP can tell us."""
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("lag1", "server1", "eth0"),),
+                instances=(_ni("mac-vrf-100", "mac-vrf", members=("lag1.100",)),),
+            ),
+            _facts(
+                "leaf2",
+                host_name="leaf2",
+                cables=(("lag1", "server1", "eth1"),),
+                instances=(_ni("mac-vrf-100", "mac-vrf", members=("lag1.100",)),),
+            ),
+        ]
+    )
+    clients = _clients(graph)
+    assert [client["name"] for client in clients] == ["server1"]
+    assert clients[0]["peers"] == ["clab-dc-leaf1", "clab-dc-leaf2"]
+    # It is a client of the fabric now, not a neighbour we failed to place.
+    assert graph["unresolved"] == []
+    assert not any(node["external"] for node in graph["nodes"])
+
+
+def test_a_client_without_lldp_or_a_segment_is_drawn_once_per_port():
+    """Two servers or one dual-homed server look the same with neither."""
+    graph = build_topology([_leaf_with_a_client("leaf1"), _leaf_with_a_client("leaf2")])
+    assert [client["name"] for client in _clients(graph)] == [
+        "clab-dc-leaf1:ethernet-1/10",
+        "clab-dc-leaf2:ethernet-1/10",
+    ]
+
+
+#: The same segment as both leaves of a multi-homing pair report it.
+ESI = "01:24:24:24:24:24:00:00:00:01"
+
+
+def _multi_homed_leaf(name: str):
+    return _facts(
+        name,
+        host_name=name,
+        site="dc1",
+        instances=(_ni("mac-vrf-100", "mac-vrf", members=("lag1.100",)),),
+        segments=(("mh-server1", ESI, "lag1"),),
+    )
+
+
+def test_one_ethernet_segment_on_two_leaves_is_one_client():
+    """Without LLDP the ESI is the only thing that says this is a single host."""
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    clients = _clients(graph)
+    assert len(clients) == 1
+    assert clients[0]["name"] == ESI
+    assert clients[0]["esi"] == ESI
+    assert clients[0]["ports"] == 2
+    # It reaches its two leaves over the bundle rather than over a cable each.
+    assert clients[0]["peers"] == [f"es:{ESI}"]
+
+
+def test_a_client_box_says_client_and_nothing_it_was_named_after():
+    """A name inferred from an ESI or a port reads like an identity it lacks."""
+    graph = build_topology([_multi_homed_leaf("leaf1"), _leaf_with_a_client("leaf2")])
+    assert [client["label"] for client in _clients(graph)] == ["client", "client"]
+
+
+def test_a_multi_homed_client_is_cabled_to_its_leaves_through_the_segment():
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    access = [link for link in graph["links"] if link["access"]]
+    # A link is keyed on its endpoints sorted, so which of the two is 'a'
+    # follows from the names rather than from one of them being the client.
+    assert [{link["a"], link["b"]} for link in access] == [
+        {ESI, f"es:{ESI}"},
+        {"clab-dc-leaf1", f"es:{ESI}"},
+        {"clab-dc-leaf2", f"es:{ESI}"},
+    ]
+
+
+def test_the_cable_from_a_segment_to_its_client_carries_no_port():
+    """It stands for the bundle, not for either of the ports that make it up."""
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    bundle = next(
+        link for link in graph["links"] if {link["a"], link["b"]} == {ESI, f"es:{ESI}"}
+    )
+    assert (bundle["ports"], bundle["count"]) == ([], 0)
+
+
+def test_a_segment_on_one_leaf_only_is_still_that_one_client():
+    graph = build_topology([_multi_homed_leaf("leaf1")])
+    client = _clients(graph)[0]
+    assert (client["name"], client["ports"]) == (ESI, 1)
+
+
+def test_the_name_a_client_advertises_wins_over_its_segment():
+    """A client that says who it is says the same to every leaf under it."""
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("lag1", "server1", "eth0"),),
+                instances=(_ni("mac-vrf-100", "mac-vrf", members=("lag1.100",)),),
+                segments=(("mh-server1", ESI, "lag1"),),
+            )
+        ]
+    )
+    client = _clients(graph)[0]
+    assert (client["name"], client["advertised"]) == ("server1", "server1")
+    # The segment is still reported, it just is not what identifies the client.
+    assert client["esi"] == ESI
+
+
+def test_a_segment_on_a_fabric_port_hangs_nothing_off_it():
+    """An ESI is no reason to draw a client where there is no service."""
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("ethernet-1/1", "spine1", "ethernet-1/1"),),
+                instances=LEAF_SERVICES,
+                segments=(("stray", ESI, "ethernet-1/1"),),
+            ),
+            _facts("spine1", host_name="spine1", instances=NO_SERVICES),
+        ]
+    )
+    assert _clients(graph) == []
+
+
+def test_a_segment_without_an_esi_is_not_an_identity():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                instances=(_ni("mac-vrf-100", "mac-vrf", members=("lag1.100",)),),
+                segments=(("half-configured", "", "lag1"),),
+            )
+        ]
+    )
+    assert _clients(graph)[0]["name"] == "clab-dc-leaf1:lag1"
+
+
+def test_the_vlan_and_the_address_of_an_attachment_come_from_the_interface_tree():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                instances=(_ni("ip-vrf-1", "ip-vrf", members=("ethernet-1/20.0",)),),
+                interfaces=(
+                    _subinterfaces(
+                        "ethernet-1/20",
+                        {
+                            "index": 0,
+                            "oper-state": "up",
+                            "vlan": {"encap": {"single-tagged": {"vlan-id": 100}}},
+                            "ipv4": {"address": [{"ip-prefix": "10.0.0.1/30"}]},
+                        },
+                    ),
+                ),
+            )
+        ]
+    )
+    attachment = _clients(graph)[0]["attachments"][0]
+    assert (attachment["vlan"], attachment["ip"]) == ("100", "10.0.0.1/30")
+    assert attachment["state"] == "up"
+
+
+def test_an_attachment_without_the_interface_tree_still_places_the_client():
+    """The vlan is an enrichment; the service alone is enough to draw the client."""
+    client = _clients(build_topology([_leaf_with_a_client()]))[0]
+    assert client["attachments"][0]["vlan"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# where the clients are drawn
+# --------------------------------------------------------------------------- #
+
+
+def test_the_clients_are_the_bottom_tier():
+    graph = build_topology(
+        [
+            _leaf_with_a_client(),
+            _facts(
+                "spine1",
+                host_name="spine1",
+                site="dc1",
+                cables=(("ethernet-1/1", "leaf1", "ethernet-1/1"),),
+                instances=NO_SERVICES,
+            ),
+        ]
+    )
+    assert [layer["label"] for layer in graph["layers"]] == ["Spines", "Leaves", "Clients"]
+    bottom = graph["layers"][-1]
+    assert (bottom["index"], bottom["nodes"]) == (0, ["clab-dc-leaf1:ethernet-1/10"])
+
+
+def test_a_client_takes_the_site_of_the_leaf_it_hangs_off():
+    client = _clients(build_topology([_leaf_with_a_client()]))[0]
+    assert client["site"] == "dc1"
+
+
+def test_the_clients_of_a_row_are_ordered_by_the_node_they_attach_to():
+    """Drawn in port-name order they would cross over each other's leaf."""
+
+    def leaf(name: str, port: str):
+        return _facts(
+            name,
+            host_name=name,
+            site="dc1",
+            instances=(_ni("mac-vrf-100", "mac-vrf", members=(f"{port}.100",)),),
+        )
+
+    graph = build_topology([leaf("leaf2", "ethernet-1/10"), leaf("leaf1", "ethernet-1/20")])
+    assert graph["layers"][-1]["nodes"] == [
+        "clab-dc-leaf1:ethernet-1/20",
+        "clab-dc-leaf2:ethernet-1/10",
+    ]
+
+
+def test_a_client_is_cabled_to_its_leaf_and_the_cable_is_marked_access():
+    graph = build_topology([_leaf_with_a_client()])
+    link = next(link for link in graph["links"] if link["b"].endswith("ethernet-1/10"))
+    assert link["a"] == "clab-dc-leaf1"
+    assert link["access"] is True
+    assert link["ports"] == [{"a_port": "ethernet-1/10", "b_port": ""}]
+
+
+def test_a_fabric_link_is_not_marked_access():
+    assert _link(build_topology(_fabric()), "leaf1", "spine1")["access"] is False
+
+
+def test_the_cable_of_a_client_that_runs_lldp_keeps_both_port_names():
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                cables=(("ethernet-1/10", "server1", "eth0"),),
+                instances=(_ni("mac-vrf-100", "mac-vrf", members=("ethernet-1/10.100",)),),
+            )
+        ]
+    )
+    link = next(link for link in graph["links"] if "server1" in (link["a"], link["b"]))
+    assert link["count"] == 1
+    assert link["ports"] == [{"a_port": "ethernet-1/10", "b_port": "eth0"}]
+    assert link["access"] is True
+
+
+def test_a_node_counts_the_clients_that_hang_off_it():
+    graph = build_topology([_leaf_with_a_client()])
+    leaf = next(node for node in graph["nodes"] if node["name"] == "clab-dc-leaf1")
+    assert leaf["clients"] == 1
+
+
+def test_a_client_does_not_change_the_tier_of_the_fabric():
+    """A leaf with customers on it is still a leaf, and its spine still a spine."""
+    plain = build_topology(_fabric())
+
+    def with_a_client(node):
+        # Only the nodes that terminate services can have a customer on them.
+        access = (
+            (_ni("mac-vrf-900", "mac-vrf", members=("ethernet-1/30.900",)),)
+            if node.mac_vrfs
+            else ()
+        )
+        return _facts(
+            node.name.removeprefix("clab-dc-"),
+            host_name=node.system_name,
+            site=node.site,
+            cables=tuple(
+                (adjacency.local_port, adjacency.peer, adjacency.peer_port)
+                for adjacency in node.adjacencies
+            ),
+            instances=tuple(_instances_of(node)) + access,
+        )
+
+    graph = build_topology([with_a_client(node) for node in _fabric()])
+    assert len(_clients(graph)) == 4  # two leaves and two gateways
+    fabric_roles = {
+        label: role for label, role in _roles(graph).items() if role != "client"
+    }
+    assert fabric_roles == _roles(plain)
+
+
+# --------------------------------------------------------------------------- #
+# the ethernet-segment tier
+# --------------------------------------------------------------------------- #
+
+
+def _segment_nodes(graph: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [node for node in graph["nodes"] if node["role"] == "segment"]
+
+
+def test_a_segment_is_a_tier_between_the_leaves_and_the_clients():
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    assert [layer["label"] for layer in graph["layers"]] == [
+        "Leaves",
+        "Ethernet segments",
+        "Clients",
+    ]
+    assert graph["layers"][1]["nodes"] == [f"es:{ESI}"]
+
+
+def test_a_segment_is_drawn_under_the_tail_of_its_esi():
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    segment = _segment_nodes(graph)[0]
+    assert (segment["label"], segment["esi"]) == ("ES 00:01", ESI)
+    assert segment["names"] == ["mh-server1"]
+    assert segment["peers"] == [ESI, "clab-dc-leaf1", "clab-dc-leaf2"]
+    assert segment["ports"] == 2
+    assert segment["clients"] == 1
+
+
+def test_two_leaves_that_disagree_on_the_name_keep_both_of_them():
+    """Nothing makes the leaves of one segment configure the same name for it."""
+    graph = build_topology(
+        [
+            _facts(
+                "leaf1",
+                host_name="leaf1",
+                instances=(_ni("mac-vrf-100", "mac-vrf", members=("lag1.100",)),),
+                segments=(("to-server1", ESI, "lag1"),),
+            ),
+            _facts(
+                "leaf2",
+                host_name="leaf2",
+                instances=(_ni("mac-vrf-100", "mac-vrf", members=("lag1.100",)),),
+                segments=(("es-1", ESI, "lag1"),),
+            ),
+        ]
+    )
+    segment = _segment_nodes(graph)[0]
+    # The ESI is what they do agree on, so it is what the box is drawn under.
+    assert segment["label"] == "ES 00:01"
+    assert segment["names"] == ["es-1", "to-server1"]
+
+
+def test_a_single_homed_client_gets_no_segment_of_its_own():
+    graph = build_topology([_leaf_with_a_client()])
+    assert _segment_nodes(graph) == []
+    assert _clients(graph)[0]["peers"] == ["clab-dc-leaf1"]
+
+
+def test_a_leaf_is_cabled_to_the_segment_rather_than_to_the_client_behind_it():
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    leaf = next(node for node in graph["nodes"] if node["name"] == "clab-dc-leaf1")
+    assert leaf["peers"] == [f"es:{ESI}"]
+    # The client behind the segment is still one of the leaf's own.
+    assert leaf["clients"] == 1
+
+
+def test_a_segment_takes_the_site_of_the_leaves_it_lands_on():
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    assert _segment_nodes(graph)[0]["site"] == "dc1"
+
+
+def test_a_segment_is_counted_as_its_own_role():
+    graph = build_topology([_multi_homed_leaf("leaf1"), _multi_homed_leaf("leaf2")])
+    assert graph["roles"] == {"leaf": 2, "segment": 1, "client": 1}


### PR DESCRIPTION
…t static assets

- Add a new Topology report that draws the fabric from LLDP and infers each node's tier (leaf, spine, DCGW, WAN/core) from the services it runs.
- Expose clients and ethernet-segments as their own tiers, merging multi-homed clients by ESI when LLDP does not identify them.
- Serve the computed graph via `GET /api/topology` and render it as an interactive SVG with hover focus, node details, and port labels.
- Fingerprint bundled JS/CSS and serve `index.html` with `Cache-Control: no-cache` so browsers pick up new UI features after upgrades.
- Subscribe to config leaves (`admin-state`, `description`, `type`, `host-name`) with datatype `all` so gNMI bootstrapping no longer stays pending silently.
- Document the topology page and API in the README, and add tests for tier inference, client/segment handling, asset versioning, and config-leaf subscriptions.