### PR TITLE
fix(clab): correct SR Linux node detection and share it between cli and mcp

### DIFF
--- a/nornir_srl/clab.py
+++ b/nornir_srl/clab.py
@@ -1,0 +1,129 @@
+"""Turning a containerlab topology file into a Nornir inventory.
+
+Both the CLI and the MCP server take a ``.clab.yml`` and have to work out which
+of its nodes are SR Linux. Keeping that in one place is what stops the two from
+drifting apart.
+"""
+
+from typing import Any, Dict, List, Optional
+
+SRL_DEFAULT_USERNAME = "admin"
+SRL_DEFAULT_PASSWORD = "NokiaSrl1!"
+SRL_DEFAULT_GNMI_PORT = 57400
+
+#: Kinds containerlab reserves for SR Linux. They identify a node on their own,
+#: whether or not the topology also pins an image.
+SRL_KINDS = ("srl", "nokia_srlinux")
+
+NORNIR_DEFAULT_CONFIG: Dict[str, Any] = {
+    "inventory": {
+        "plugin": "YAMLInventory",
+        "options": {
+            "host_file": "clab_hosts.yml",
+            "group_file": "clab_groups.yml",
+            "defaults_file": "clab_defaults.yml",
+        },
+    },
+    "runner": {"plugin": "threaded", "options": {"num_workers": 20}},
+    "user_defined": {"intent_dir": "intent"},
+    "logging": {"enabled": False},
+}
+
+
+def _mapping(parent: Any, key: Any) -> Dict[str, Any]:
+    """``parent[key]`` as a mapping, treating absent and empty YAML alike.
+
+    A key written without a value - ``defaults:`` on a line of its own, or a
+    node listed as bare ``leaf1:`` - parses as ``None``, which a plain
+    ``.get(key, {})`` would hand straight to the next lookup.
+    """
+    if not isinstance(parent, dict):
+        return {}
+    value = parent.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def node_prefix(topo: Dict[str, Any]) -> str:
+    """The name containerlab prepends to every node in *topo*."""
+    lab_name = topo["name"]
+    if "prefix" not in topo:
+        return f"clab-{lab_name}-"
+    prefix = topo["prefix"]
+    if prefix == "__lab-name":
+        return f"{lab_name}-"
+    if prefix == "":
+        return ""
+    return f"{prefix}-{lab_name}-"
+
+
+def srl_kinds(topology: Dict[str, Any]) -> List[str]:
+    """Every kind in *topology* that denotes an SR Linux node."""
+    kinds = _mapping(topology, "kinds")
+    found = [
+        kind
+        for kind in kinds
+        if "/srlinux" in (_mapping(kinds, kind).get("image") or "")
+    ]
+    for reserved in SRL_KINDS:
+        if reserved not in found:
+            found.append(reserved)
+    return found
+
+
+def _srlinux_by_default(topology: Dict[str, Any]) -> bool:
+    """Whether a node that names no kind of its own is an SR Linux node."""
+    defaults = _mapping(topology, "defaults")
+    default_kind = defaults.get("kind")
+    if default_kind in SRL_KINDS:
+        return True
+    # A default image can be pinned directly or inherited from the default
+    # kind's entry under 'kinds', and either one settles it on its own.
+    default_image = defaults.get("image") or _mapping(
+        _mapping(topology, "kinds"), default_kind
+    ).get("image")
+    return bool(default_image and "srlinux" in default_image)
+
+
+def srl_hosts(topo: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """The SR Linux nodes of *topo*, as a Nornir hosts inventory."""
+    topology = _mapping(topo, "topology")
+    prefix = node_prefix(topo)
+    kinds = srl_kinds(topology)
+    by_default = _srlinux_by_default(topology)
+
+    nodes = _mapping(topology, "nodes")
+    hosts: Dict[str, Dict[str, Any]] = {}
+    for node in nodes:
+        node_spec = _mapping(nodes, node)
+        node_kind = node_spec.get("kind")
+        if (node_kind is None and by_default) or node_kind in kinds:
+            name = f"{prefix}{node}"
+            hosts[name] = {
+                "hostname": name,
+                "platform": "srlinux",
+                "groups": ["srl"],
+                "data": _mapping(node_spec, "labels"),
+            }
+    return hosts
+
+
+def srl_groups(
+    gnmi_port: int = SRL_DEFAULT_GNMI_PORT,
+    cert_file: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """The Nornir groups inventory the hosts from :func:`srl_hosts` belong to."""
+    extras: Dict[str, Any] = {}
+    if cert_file:
+        extras["path_cert"] = str(cert_file)
+    return {
+        "srl": {
+            "connection_options": {
+                "srlinux": {
+                    "username": SRL_DEFAULT_USERNAME,
+                    "password": SRL_DEFAULT_PASSWORD,
+                    "port": gnmi_port,
+                    "extras": extras,
+                }
+            }
+        }
+    }

--- a/nornir_srl/cli.py
+++ b/nornir_srl/cli.py
@@ -18,6 +18,7 @@ from nornir import InitNornir
 from nornir.core import Nornir
 from nornir.core.task import Result, Task, AggregatedResult
 
+from . import clab
 from .connections.srlinux import CONNECTION_NAME
 from .connections.routing import BGP_RIB_ROUTE_FAM_ALIASES
 from .connections.helpers import clean_structured_key
@@ -52,23 +53,8 @@ app = typer.Typer(name="fcli", help="Nornir SRLinux CLI")
 logger = logging.getLogger(__name__)
 
 
-SRL_DEFAULT_USERNAME = "admin"
-SRL_DEFAULT_PASSWORD = "NokiaSrl1!"
-SRL_DEFAULT_GNMI_PORT = 57400
-
-NORNIR_DEFAULT_CONFIG: Dict[str, Any] = {
-    "inventory": {
-        "plugin": "YAMLInventory",
-        "options": {
-            "host_file": "clab_hosts.yml",
-            "group_file": "clab_groups.yml",
-            "defaults_file": "clab_defaults.yml",
-        },
-    },
-    "runner": {"plugin": "threaded", "options": {"num_workers": 20}},
-    "user_defined": {"intent_dir": "intent"},
-    "logging": {"enabled": False},
-}
+SRL_DEFAULT_GNMI_PORT = clab.SRL_DEFAULT_GNMI_PORT
+NORNIR_DEFAULT_CONFIG = clab.NORNIR_DEFAULT_CONFIG
 
 
 # ------------------------- helpers -------------------------
@@ -282,63 +268,8 @@ def main(
             typer.echo(f"Failed to load topology file {topo_file}: {e}")
             raise typer.Exit(1)
         lab_name = topo["name"]
-        if "prefix" not in topo:
-            prefix = f"clab-{lab_name}-"
-        else:
-            if topo["prefix"] == "__lab-name":
-                prefix = f"{lab_name}-"
-            elif topo["prefix"] == "":
-                prefix = ""
-            else:
-                prefix = f"{topo['prefix']}-{lab_name}-"
-        hosts: Dict[str, Dict[str, Any]] = {}
-        def_kind = topo["topology"].get("defaults", {}).get("kind")
-        def_image = (
-            topo["topology"].get("defaults", {}).get("image")
-            or topo["topology"]["kinds"].get(def_kind, {}).get("image")
-            if def_kind
-            else None
-        )
-        srlinux_def = False
-        if def_image and "srlinux" in def_image:
-            srlinux_def = True
-        if def_kind in {"srl", "nokia_srlinux"}:
-            srlinux_def = True
-
-        srl_kinds = [
-            k
-            for k, v in topo["topology"].get("kinds", {}).items()
-            if "/srlinux" in v.get("image")
-        ]
-        for extra in ("srl", "nokia_srlinux"):
-            if extra not in srl_kinds:
-                srl_kinds.append(extra)
-        clab_nodes: Dict[str, Dict] = topo["topology"]["nodes"]
-        for node, node_spec in clab_nodes.items():
-            node_kind = node_spec.get("kind")
-            if (node_kind is None and srlinux_def) or node_kind in srl_kinds:
-                hosts[f"{prefix}{node}"] = {
-                    "hostname": f"{prefix}{node}",
-                    "platform": "srlinux",
-                    "groups": ["srl"],
-                    "data": node_spec.get("labels", {}),
-                }
-        groups: Dict[str, Dict[str, Any]] = {
-            "srl": {
-                "connection_options": {
-                    "srlinux": {
-                        "username": SRL_DEFAULT_USERNAME,
-                        "password": SRL_DEFAULT_PASSWORD,
-                        "port": gnmi_port,
-                        "extras": {},
-                    }
-                }
-            }
-        }
-        if cert_file:
-            groups["srl"]["connection_options"]["srlinux"]["extras"]["path_cert"] = str(
-                cert_file
-            )
+        hosts = clab.srl_hosts(topo)
+        groups = clab.srl_groups(gnmi_port, str(cert_file) if cert_file else None)
         with tempfile.NamedTemporaryFile("w+") as hosts_f:
             yaml.safe_dump(hosts, hosts_f)
             hosts_f.seek(0)

--- a/nornir_srl/mcp_server.py
+++ b/nornir_srl/mcp_server.py
@@ -35,6 +35,7 @@ from nornir import InitNornir
 from nornir.core import Nornir
 from nornir.core.task import Result, Task
 
+from . import clab
 from .connections.srlinux import CONNECTION_NAME
 from .connections.helpers import clean_structured_key
 from .reports import ReportSpec, get_report
@@ -42,23 +43,8 @@ from .rows import extract
 
 logger = logging.getLogger(__name__)
 
-SRL_DEFAULT_USERNAME = "admin"
-SRL_DEFAULT_PASSWORD = "NokiaSrl1!"
-SRL_DEFAULT_GNMI_PORT = 57400
-
-NORNIR_DEFAULT_CONFIG: Dict[str, Any] = {
-    "inventory": {
-        "plugin": "YAMLInventory",
-        "options": {
-            "host_file": "clab_hosts.yml",
-            "group_file": "clab_groups.yml",
-            "defaults_file": "clab_defaults.yml",
-        },
-    },
-    "runner": {"plugin": "threaded", "options": {"num_workers": 20}},
-    "user_defined": {"intent_dir": "intent"},
-    "logging": {"enabled": False},
-}
+SRL_DEFAULT_GNMI_PORT = clab.SRL_DEFAULT_GNMI_PORT
+NORNIR_DEFAULT_CONFIG = clab.NORNIR_DEFAULT_CONFIG
 
 
 # ---- Nornir initialization ----
@@ -90,67 +76,8 @@ def _init_nornir_from_topo(
     with open(topo_file, "r") as f:
         topo = yaml.safe_load(os.path.expandvars(f.read()))
 
-    lab_name = topo["name"]
-    if "prefix" not in topo:
-        prefix = f"clab-{lab_name}-"
-    else:
-        if topo["prefix"] == "__lab-name":
-            prefix = f"{lab_name}-"
-        elif topo["prefix"] == "":
-            prefix = ""
-        else:
-            prefix = f"{topo['prefix']}-{lab_name}-"
-
-    hosts: Dict[str, Dict[str, Any]] = {}
-    def_kind = topo["topology"].get("defaults", {}).get("kind")
-    def_image = (
-        topo["topology"].get("defaults", {}).get("image")
-        or topo["topology"]["kinds"].get(def_kind, {}).get("image")
-        if def_kind
-        else None
-    )
-    srlinux_def = False
-    if def_image and "srlinux" in def_image:
-        srlinux_def = True
-    if def_kind in {"srl", "nokia_srlinux"}:
-        srlinux_def = True
-
-    srl_kinds = [
-        k
-        for k, v in topo["topology"].get("kinds", {}).items()
-        if "/srlinux" in v.get("image", "")
-    ]
-    for extra in ("srl", "nokia_srlinux"):
-        if extra not in srl_kinds:
-            srl_kinds.append(extra)
-
-    clab_nodes: Dict[str, Dict] = topo["topology"]["nodes"]
-    for node, node_spec in clab_nodes.items():
-        node_kind = node_spec.get("kind")
-        if (node_kind is None and srlinux_def) or node_kind in srl_kinds:
-            hosts[f"{prefix}{node}"] = {
-                "hostname": f"{prefix}{node}",
-                "platform": "srlinux",
-                "groups": ["srl"],
-                "data": node_spec.get("labels", {}),
-            }
-
-    groups: Dict[str, Dict[str, Any]] = {
-        "srl": {
-            "connection_options": {
-                "srlinux": {
-                    "username": SRL_DEFAULT_USERNAME,
-                    "password": SRL_DEFAULT_PASSWORD,
-                    "port": gnmi_port,
-                    "extras": {},
-                }
-            }
-        }
-    }
-    if cert_file:
-        groups["srl"]["connection_options"]["srlinux"]["extras"][
-            "path_cert"
-        ] = cert_file
+    hosts = clab.srl_hosts(topo)
+    groups = clab.srl_groups(gnmi_port, cert_file)
 
     hosts_f = tempfile.NamedTemporaryFile("w+", suffix=".yml", delete=False)
     yaml.safe_dump(hosts, hosts_f)

--- a/tests/test_clab.py
+++ b/tests/test_clab.py
@@ -1,0 +1,243 @@
+"""Tests for turning a containerlab topology into a Nornir inventory."""
+
+import yaml
+
+from nornir_srl import clab
+
+
+def topo(text: str):
+    return yaml.safe_load(text)
+
+
+# --------------------------------------------------------------------------- #
+# node prefix
+# --------------------------------------------------------------------------- #
+
+
+def test_prefix_defaults_to_clab_labname():
+    assert clab.node_prefix(topo("name: lab1")) == "clab-lab1-"
+
+
+def test_prefix_lab_name_keyword_drops_the_clab_part():
+    assert clab.node_prefix(topo("name: lab1\nprefix: __lab-name")) == "lab1-"
+
+
+def test_empty_prefix_leaves_node_names_alone():
+    assert clab.node_prefix(topo('name: lab1\nprefix: ""')) == ""
+
+
+def test_custom_prefix_keeps_the_lab_name():
+    assert clab.node_prefix(topo("name: lab1\nprefix: acme")) == "acme-lab1-"
+
+
+# --------------------------------------------------------------------------- #
+# which nodes are SR Linux
+# --------------------------------------------------------------------------- #
+
+
+def test_kind_under_defaults_covers_nodes_that_name_none():
+    """The idiomatic topology: everything inherited, nodes written bare.
+
+    A node listed as ``leaf1:`` with nothing under it parses as None, which
+    used to be handed straight to .get().
+    """
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              defaults:
+                kind: nokia_srlinux
+                image: ghcr.io/nokia/srlinux:24.7.1
+              nodes:
+                leaf1:
+                leaf2:
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1", "clab-lab1-leaf2"]
+
+
+def test_default_kind_without_a_kinds_section():
+    """'kinds' is optional - an image pinned per node is enough for clab."""
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              defaults:
+                kind: nokia_srlinux
+              nodes:
+                leaf1:
+                  image: ghcr.io/nokia/srlinux:24.7.1
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1"]
+
+
+def test_kind_entry_carrying_no_image():
+    """A 'kinds' entry may set type or binds and leave the image to the node."""
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              kinds:
+                nokia_srlinux:
+                  type: ixrd3
+              nodes:
+                leaf1:
+                  kind: nokia_srlinux
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1"]
+
+
+def test_default_image_counts_without_a_default_kind():
+    """The bug from issue #23: 'A or B if kind else None' dropped A.
+
+    Precedence made the whole 'or' conditional on a default kind being set, so
+    an image pinned directly under defaults was thrown away.
+    """
+    topology = topo(
+        """
+        name: lab1
+        topology:
+          defaults:
+            image: ghcr.io/nokia/srlinux:24.7.1
+          nodes:
+            leaf1: {}
+        """
+    )
+    assert sorted(clab.srl_hosts(topology)) == ["clab-lab1-leaf1"]
+
+
+def test_image_under_kinds_identifies_a_custom_kind_name():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              kinds:
+                my-srl:
+                  image: ghcr.io/nokia/srlinux:24.7.1
+              nodes:
+                leaf1:
+                  kind: my-srl
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1"]
+
+
+def test_nodes_of_other_kinds_stay_out_of_the_inventory():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              kinds:
+                nokia_srlinux:
+                  image: ghcr.io/nokia/srlinux:24.7.1
+                linux:
+                  image: ghcr.io/srl-labs/network-multitool
+              nodes:
+                leaf1:
+                  kind: nokia_srlinux
+                client1:
+                  kind: linux
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1"]
+
+
+def test_a_bare_node_is_not_srlinux_without_a_default_saying_so():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              nodes:
+                leaf1:
+            """
+        )
+    )
+    assert hosts == {}
+
+
+def test_empty_sections_are_read_as_absent():
+    """Every clab section can be written as a key with nothing under it."""
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              defaults:
+              kinds:
+              nodes:
+                leaf1:
+                  kind: srl
+                  labels:
+            """
+        )
+    )
+    assert hosts["clab-lab1-leaf1"]["data"] == {}
+
+
+def test_labels_are_carried_over_as_host_data():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              nodes:
+                leaf1:
+                  kind: nokia_srlinux
+                  labels:
+                    role: leaf
+                    site: dc1
+            """
+        )
+    )
+    assert hosts["clab-lab1-leaf1"]["data"] == {"role": "leaf", "site": "dc1"}
+
+
+def test_hosts_carry_the_prefixed_name_and_platform():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              nodes:
+                leaf1:
+                  kind: srl
+            """
+        )
+    )
+    assert hosts["clab-lab1-leaf1"] == {
+        "hostname": "clab-lab1-leaf1",
+        "platform": "srlinux",
+        "groups": ["srl"],
+        "data": {},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# groups
+# --------------------------------------------------------------------------- #
+
+
+def test_groups_carry_the_gnmi_port():
+    options = clab.srl_groups(57410)["srl"]["connection_options"]["srlinux"]
+    assert options["port"] == 57410
+    assert options["extras"] == {}
+
+
+def test_a_cert_file_is_passed_to_the_connection():
+    options = clab.srl_groups(57400, "/tmp/ca.pem")["srl"]["connection_options"][
+        "srlinux"
+    ]
+    assert options["extras"]["path_cert"] == "/tmp/ca.pem"


### PR DESCRIPTION
Fixes #23.

## What was wrong

The containerlab inventory builder was duplicated in `cli.py` and `mcp_server.py`, and both copies mis-detected SR Linux nodes in topologies that containerlab itself deploys without complaint.

The expression flagged in #23 is the root of two of these:

```python
def_image = (
    topo["topology"].get("defaults", {}).get("image")
    or topo["topology"]["kinds"].get(def_kind, {}).get("image")
    if def_kind
    else None
)
```

`A or B if def_kind else None` parses as `(A or B) if def_kind else None`, so `defaults.image` is discarded whenever `defaults.kind` is absent. That same branch is also the only thing that reaches `topo["topology"]["kinds"]` as a direct subscript rather than a `.get()`.

Each case below was checked against `clab deploy --dry-run` to confirm containerlab accepts it, then run through `fcli`:

| Topology | Valid clab? | Before | After |
|---|---|---|---|
| `defaults.image`, no `defaults.kind` | No | inventory silently empty | detected |
| `defaults.kind`, no `kinds:` section | Yes | `KeyError: 'kinds'` | detected |
| `kinds:` entry without `image` | Yes | `TypeError: argument of type 'NoneType' is not iterable` | detected |
| bare nodes (`leaf1:`) + `defaults.kind`/`image` | Yes | `AttributeError: 'NoneType' object has no attribute 'get'` | detected |
| `defaults.kind` + `kinds.<kind>.image` | Yes | works | works |

The first row is the literal scenario in #23 and is the least reachable, since containerlab requires a kind and rejects that topology. The other three are deployable, which is why this is worth more than a one-line precedence fix.

Row three is also a drift artifact: `mcp_server.py` already used `v.get("image", "")` while `cli.py` still used the unguarded `v.get("image")`, so a previous fix had only been applied to one of the two copies.

## What changed

New `nornir_srl/clab.py` owns the logic once (`node_prefix`, `srl_kinds`, `srl_hosts`, `srl_groups`, plus the credential and Nornir config constants that were also duplicated). Both entry points call into it, removing 152 lines across the two files.

Three of the four bugs are the same shape — a YAML key written with nothing under it parses as `None` — so optional sections are now read through a single `_mapping()` helper that treats absent and empty alike.

## Verification

- `tests/test_clab.py` adds 16 tests. Restoring the old logic makes 6 of them fail with exactly the `AttributeError`, `KeyError`, and `TypeError` seen from the CLI, so they are real regression guards rather than tests that merely pass.
- Full suite: 810 passing.
- Live 34-node lab (`defaults.kind` + `kinds.<kind>.image`): unchanged at 22 SR Linux hosts with the 12 `linux` nodes excluded, confirmed end to end with `fcli -p 57410 sys-info`.

Made with [Cursor](https://cursor.com)