### PR TITLE
fix(clab): honor containerlab group inheritance for kind, image and l…

### DIFF
--- a/nornir_srl/clab.py
+++ b/nornir_srl/clab.py
@@ -5,7 +5,7 @@ of its nodes are SR Linux. Keeping that in one place is what stops the two from
 drifting apart.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 SRL_DEFAULT_USERNAME = "admin"
 SRL_DEFAULT_PASSWORD = "NokiaSrl1!"
@@ -56,54 +56,61 @@ def node_prefix(topo: Dict[str, Any]) -> str:
     return f"{prefix}-{lab_name}-"
 
 
-def srl_kinds(topology: Dict[str, Any]) -> List[str]:
-    """Every kind in *topology* that denotes an SR Linux node."""
-    kinds = _mapping(topology, "kinds")
-    found = [
-        kind
-        for kind in kinds
-        if "/srlinux" in (_mapping(kinds, kind).get("image") or "")
-    ]
-    for reserved in SRL_KINDS:
-        if reserved not in found:
-            found.append(reserved)
-    return found
+def _inherited(topology: Dict[str, Any], node_spec: Dict[str, Any], key: str) -> Any:
+    """The value of *key* for a node, down containerlab's inheritance chain.
+
+    A node's own setting wins, then the group it is in, then the topology
+    defaults. ``kinds`` is not a link in that chain: it is keyed by the kind
+    the chain settles on, so it can only be read once that kind is known.
+    """
+    group = _mapping(_mapping(topology, "groups"), node_spec.get("group"))
+    for source in (node_spec, group, _mapping(topology, "defaults")):
+        value = source.get(key)
+        if value:
+            return value
+    return None
 
 
-def _srlinux_by_default(topology: Dict[str, Any]) -> bool:
-    """Whether a node that names no kind of its own is an SR Linux node."""
-    defaults = _mapping(topology, "defaults")
-    default_kind = defaults.get("kind")
-    if default_kind in SRL_KINDS:
+def is_srl_node(topology: Dict[str, Any], node_spec: Dict[str, Any]) -> bool:
+    """Whether the node described by *node_spec* is an SR Linux node.
+
+    The kind the node inherits settles it, and for a kind whose name
+    containerlab does not reserve, the image behind that kind does.
+    """
+    kind = _inherited(topology, node_spec, "kind")
+    if kind in SRL_KINDS:
         return True
-    # A default image can be pinned directly or inherited from the default
-    # kind's entry under 'kinds', and either one settles it on its own.
-    default_image = defaults.get("image") or _mapping(
-        _mapping(topology, "kinds"), default_kind
-    ).get("image")
-    return bool(default_image and "srlinux" in default_image)
+    kind_image = _mapping(_mapping(topology, "kinds"), kind).get("image")
+    return "srlinux" in (kind_image or _inherited(topology, node_spec, "image") or "")
+
+
+def _labels(topology: Dict[str, Any], node_spec: Dict[str, Any]) -> Dict[str, Any]:
+    """A node's labels, with the ones it inherits merged in underneath."""
+    group = _mapping(_mapping(topology, "groups"), node_spec.get("group"))
+    labels = dict(_mapping(_mapping(topology, "defaults"), "labels"))
+    labels.update(_mapping(group, "labels"))
+    labels.update(_mapping(node_spec, "labels"))
+    return labels
 
 
 def srl_hosts(topo: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     """The SR Linux nodes of *topo*, as a Nornir hosts inventory."""
     topology = _mapping(topo, "topology")
     prefix = node_prefix(topo)
-    kinds = srl_kinds(topology)
-    by_default = _srlinux_by_default(topology)
 
     nodes = _mapping(topology, "nodes")
     hosts: Dict[str, Dict[str, Any]] = {}
     for node in nodes:
         node_spec = _mapping(nodes, node)
-        node_kind = node_spec.get("kind")
-        if (node_kind is None and by_default) or node_kind in kinds:
-            name = f"{prefix}{node}"
-            hosts[name] = {
-                "hostname": name,
-                "platform": "srlinux",
-                "groups": ["srl"],
-                "data": _mapping(node_spec, "labels"),
-            }
+        if not is_srl_node(topology, node_spec):
+            continue
+        name = f"{prefix}{node}"
+        hosts[name] = {
+            "hostname": name,
+            "platform": "srlinux",
+            "groups": ["srl"],
+            "data": _labels(topology, node_spec),
+        }
     return hosts
 
 

--- a/tests/test_clab.py
+++ b/tests/test_clab.py
@@ -205,6 +205,124 @@ def test_labels_are_carried_over_as_host_data():
     assert hosts["clab-lab1-leaf1"]["data"] == {"role": "leaf", "site": "dc1"}
 
 
+def test_kind_inherited_from_a_group():
+    """'groups' sits between 'kinds' and the nodes in clab's chain.
+
+    A topology can hang the kind off a group and leave every node with only
+    'group:', which used to leave the inventory empty.
+    """
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              groups:
+                leaf:
+                  kind: nokia_srlinux
+                  image: ghcr.io/nokia/srlinux:25.10.4
+                host:
+                  kind: linux
+                  image: ghcr.io/srl-labs/network-multitool
+              nodes:
+                leaf1:
+                  group: leaf
+                leaf2:
+                  group: leaf
+                host1:
+                  group: host
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1", "clab-lab1-leaf2"]
+
+
+def test_a_group_image_identifies_a_custom_kind_name():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              groups:
+                leaf:
+                  kind: my-srl
+                  image: ghcr.io/nokia/srlinux:25.10.4
+              nodes:
+                leaf1:
+                  group: leaf
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1"]
+
+
+def test_a_node_kind_overrides_the_group_it_is_in():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              groups:
+                edge:
+                  kind: linux
+                  image: quay.io/frrouting/frr:master
+              nodes:
+                leaf1:
+                  group: edge
+                  kind: nokia_srlinux
+                frr1:
+                  group: edge
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1"]
+
+
+def test_a_group_overrides_the_topology_defaults():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              defaults:
+                kind: nokia_srlinux
+                image: ghcr.io/nokia/srlinux:25.10.4
+              groups:
+                host:
+                  kind: linux
+                  image: ghcr.io/srl-labs/network-multitool
+              nodes:
+                leaf1:
+                host1:
+                  group: host
+            """
+        )
+    )
+    assert sorted(hosts) == ["clab-lab1-leaf1"]
+
+
+def test_group_labels_are_merged_under_the_node_labels():
+    hosts = clab.srl_hosts(
+        topo(
+            """
+            name: lab1
+            topology:
+              groups:
+                leaf:
+                  kind: nokia_srlinux
+                  labels:
+                    role: leaf
+                    site: dc1
+              nodes:
+                leaf1:
+                  group: leaf
+                  labels:
+                    site: dc2
+            """
+        )
+    )
+    assert hosts["clab-lab1-leaf1"]["data"] == {"role": "leaf", "site": "dc2"}
+
+
 def test_hosts_carry_the_prefixed_name_and_platform():
     hosts = clab.srl_hosts(
         topo(


### PR DESCRIPTION
…abels

Replace the flat SR Linux node detection with one that follows containerlab's inheritance chain: node, then group, then defaults. This lets nodes inherit `kind`/`image` from a `group:` block and still be recognized as SR Linux, and correctly handles custom kind names whose image contains `srlinux`.

Also merge labels from defaults, group, and node (later wins) into the host `data` instead of only reading the node's labels.

Add tests for kind/image inheritance through groups, overrides between node/group/defaults, and merged labels.